### PR TITLE
Remove newlines from VERSION command. Fix for #16

### DIFF
--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -22,7 +22,7 @@ extern const PROGMEM CommandEntryType CommandTable[];
 CommandStatusIdType CommandGetVersion(char* OutParam)
 {
   snprintf_P(OutParam, TERMINAL_BUFFER_SIZE, PSTR(
-    "ChameleonMini RevG %S using LUFA %S compiled with AVR-GCC %S\r\nBased on the open-source NFC tool ChameleonMini\r\nhttps://github.com/emsec/ChameleonMini\r\ncommit %S"
+    "ChameleonMini RevG %S using LUFA %S compiled with AVR-GCC %S. Based on the open-source NFC tool ChameleonMini. https://github.com/emsec/ChameleonMini commit %S"
     ), PSTR(CHAMELEON_MINI_VERSION_STRING), PSTR(LUFA_VERSION_STRING), PSTR(__VERSION__), PSTR(COMMIT_ID)
   );
 


### PR DESCRIPTION
I would propose this fix for #16 which removes the additional newlines in the response of the VERSION command.

The specification states for "101:OK WITH TEXT": "The command has been successfully executed and this response is appended with an additional line of information, terminated with CR+LF"

Maybe the formatting of this line could be improved, but this should so far fix the issue with the chamtool.

I would rather fix this in the way displayed here than to include an exception in the chamtool code, as proposed in #19.