### PR TITLE
make CRCA checking const-correct

### DIFF
--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
@@ -52,9 +52,9 @@ void ISO14443AAppendCRCA(void* Buffer, uint16_t ByteCount)
 #endif
 
 #ifdef USE_HW_CRC
-bool ISO14443ACheckCRCA(void* Buffer, uint16_t ByteCount)
+bool ISO14443ACheckCRCA(const void* Buffer, uint16_t ByteCount)
 {
-    uint8_t* DataPtr = (uint8_t*) Buffer;
+    const uint8_t* DataPtr = (const uint8_t*) Buffer;
 
     CRC.CTRL = CRC_RESET0_bm;
     CRC.CHECKSUM1 = (CRC_INIT_R >> 8) & 0xFF;
@@ -76,10 +76,10 @@ bool ISO14443ACheckCRCA(void* Buffer, uint16_t ByteCount)
 }
 #else
 #include <util/crc16.h>
-bool ISO14443ACheckCRCA(void* Buffer, uint16_t ByteCount)
+bool ISO14443ACheckCRCA(const void* Buffer, uint16_t ByteCount)
 {
     uint16_t Checksum = CRC_INIT;
-    uint8_t* DataPtr = (uint8_t*) Buffer;
+    const uint8_t* DataPtr = (const uint8_t*) Buffer;
 
     while(ByteCount--) {
         uint8_t Byte = *DataPtr++;

--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
@@ -45,7 +45,7 @@
     ( ByteBuffer[0] ^ ByteBuffer[1] ^ ByteBuffer[2] ^ ByteBuffer[3] )
 
 void ISO14443AAppendCRCA(void* Buffer, uint16_t ByteCount);
-bool ISO14443ACheckCRCA(void* Buffer, uint16_t ByteCount);
+bool ISO14443ACheckCRCA(const void* Buffer, uint16_t ByteCount);
 
 INLINE bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue);
 INLINE bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue);


### PR DESCRIPTION
Ensure code compiles w/o warnings when checking ISO14443-3 CRCA on const buffers. Might produce smaller/faster code as an additional benefit.