### PR TITLE
fix build on Windows

### DIFF
--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -72,7 +72,11 @@ SPM_HELPER_ADDR = 0x21FE0 #Start of SPM helper section. Should be last 32Byte in
 SPM_HELPER_OBJCOPY = --set-section-flags=.spmhelper="alloc,load"
 
 #Build configuration
-BUILD_DATE	 = $(shell date +'\"%y%m%d\"')
+ifeq ($(OS),Windows_NT)
+BUILD_DATE   = $(shell date /t)
+else
+BUILD_DATE   = $(shell date +'%y%m%d')
+endif
 COMMIT_ID	 = $(shell git rev-parse --short HEAD)
 MCU          = atxmega128a4u
 ARCH         = XMEGA


### PR DESCRIPTION
This ensures the firmware can be built OK on Windows using avr-gcc only, not requiring a full msys/mingw environment. There are a few quirks remaining with LUFA's makefiles using grep etc, but this does not actually prevent building.