### PR TITLE
Added udev rule in Drivers/

### DIFF
--- a/Driver/98-ChameleonMini.rules
+++ b/Driver/98-ChameleonMini.rules
@@ -1,0 +1,2 @@
+# Rule for ChameleonMini RFID Research tool
+ATTRS{product}=="Chameleon-Mini", SUBSYSTEMS=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="04b2", GROUP="users", MODE="0666", SYMLINK+="chameleon"


### PR DESCRIPTION
Added udev rule, allowing non root users on a linux system(assuming udev is used) to open the serial port and talk with the chameleon.
Also included symlink in rule, so the interface always shows as /dev/chameleon.