### PR TITLE
Handle HALT properly

### DIFF
--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
@@ -138,11 +138,12 @@ bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t S
     }
 }
 
-bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue)
+bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt)
 {
     uint8_t* DataPtr = (uint8_t*) Buffer;
 
-    if ( (DataPtr[0] == ISO14443A_CMD_REQA) || (DataPtr[0] == ISO14443A_CMD_WUPA) ){
+    if ( ((! FromHalt) && (DataPtr[0] == ISO14443A_CMD_REQA)) ||
+         (DataPtr[0] == ISO14443A_CMD_WUPA) ){
         DataPtr[0] = (ATQAValue >> 0) & 0x00FF;
         DataPtr[1] = (ATQAValue >> 8) & 0x00FF;
 
@@ -153,4 +154,5 @@ bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue)
         return false;
     }
 }
+
 #endif

--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
@@ -48,7 +48,7 @@ void ISO14443AAppendCRCA(void* Buffer, uint16_t ByteCount);
 bool ISO14443ACheckCRCA(void* Buffer, uint16_t ByteCount);
 
 INLINE bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue);
-INLINE bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue);
+INLINE bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt);
 
 INLINE
 bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue)
@@ -98,11 +98,12 @@ bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t S
 }
 
 INLINE
-bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue)
+bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt)
 {
     uint8_t* DataPtr = (uint8_t*) Buffer;
 
-    if ( (DataPtr[0] == ISO14443A_CMD_REQA) || (DataPtr[0] == ISO14443A_CMD_WUPA) ){
+    if ( ((! FromHalt) && (DataPtr[0] == ISO14443A_CMD_REQA)) ||
+         (DataPtr[0] == ISO14443A_CMD_WUPA) ){
         DataPtr[0] = (ATQAValue >> 0) & 0x00FF;
         DataPtr[1] = (ATQAValue >> 8) & 0x00FF;
 

--- a/Firmware/Chameleon-Mini/Application/MifareClassic.c
+++ b/Firmware/Chameleon-Mini/Application/MifareClassic.c
@@ -163,7 +163,7 @@ uint16_t MifareClassicAppProcess(uint8_t* Buffer, uint16_t BitCount)
     switch(State) {
     case STATE_IDLE:
     case STATE_HALT:
-        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue)) {
+        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, State == STATE_HALT)) {
             State = STATE_READY1;
             return BitCount;
         }
@@ -252,7 +252,7 @@ uint16_t MifareClassicAppProcess(uint8_t* Buffer, uint16_t BitCount)
 #endif
 
     case STATE_READY1:
-        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue)) {
+        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, false)) {
             State = STATE_READY1;
             return BitCount;
         } else if (Buffer[0] == ISO14443A_CMD_SELECT_CL1) {
@@ -278,7 +278,7 @@ uint16_t MifareClassicAppProcess(uint8_t* Buffer, uint16_t BitCount)
         break;
 
     case STATE_READY2:
-    if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue)) {
+    if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, false)) {
 	    State = STATE_READY1;
 	    return BitCount;
 	    } else if (Buffer[0] == ISO14443A_CMD_SELECT_CL2) {
@@ -297,7 +297,7 @@ uint16_t MifareClassicAppProcess(uint8_t* Buffer, uint16_t BitCount)
     }
     break;
     case STATE_ACTIVE:
-        if (ISO14443AWakeUp(Buffer, &BitCount, MFCLASSIC_1K_ATQA_VALUE)) {
+        if (ISO14443AWakeUp(Buffer, &BitCount, MFCLASSIC_1K_ATQA_VALUE, false)) {
             State = STATE_READY1;
             return BitCount;
         } else if (Buffer[0] == CMD_HALT) {

--- a/Firmware/Chameleon-Mini/Application/MifareUltralight.c
+++ b/Firmware/Chameleon-Mini/Application/MifareUltralight.c
@@ -86,7 +86,7 @@ uint16_t MifareUltralightAppProcess(uint8_t* Buffer, uint16_t BitCount)
     switch(State) {
     case STATE_IDLE:
     case STATE_HALT:
-        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE)) {
+        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE, State == STATE_HALT)) {
             /* We received a REQA or WUPA command, so wake up. */
             State = STATE_READY1;
             return BitCount;
@@ -94,7 +94,7 @@ uint16_t MifareUltralightAppProcess(uint8_t* Buffer, uint16_t BitCount)
         break;
 
     case STATE_READY1:
-        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE)) {
+        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE, false)) {
             State = STATE_READY1;
             return BitCount;
         } else if (Cmd == ISO14443A_CMD_SELECT_CL1) {
@@ -118,7 +118,7 @@ uint16_t MifareUltralightAppProcess(uint8_t* Buffer, uint16_t BitCount)
         break;
 
     case STATE_READY2:
-        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE)) {
+        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE, false)) {
             State = STATE_READY1;
             return BitCount;
         } else if (Cmd == ISO14443A_CMD_SELECT_CL2) {
@@ -141,7 +141,7 @@ uint16_t MifareUltralightAppProcess(uint8_t* Buffer, uint16_t BitCount)
         break;
 
     case STATE_ACTIVE:
-        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE)) {
+        if (ISO14443AWakeUp(Buffer, &BitCount, ATQA_VALUE, false)) {
             State = STATE_READY1;
             return BitCount;
         } else if (Cmd == CMD_READ) {


### PR DESCRIPTION
Hi,

Proposal to fix https://github.com/emsec/ChameleonMini/issues/46
Note that the state machine of the emulators is still probably not exactly the same as in the specs (e.g. it should return to IDLE or HALT depending if it came from IDLE or HALT) but at least now it works with readers which are counting on  proper STATE_HALT