### PR TITLE
Fix python #! and exec rights

### DIFF
--- a/Software/chamlog.py
+++ b/Software/chamlog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Command line tool to analyze binary dump files from the Chameleon
 # Authors: Simon K. (simon.kueppers@rub.de)

--- a/Software/chamtool.py
+++ b/Software/chamtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Command line tool to control the Chameleon through command line
 # Authors: Simon K. (simon.kueppers@rub.de)


### PR DESCRIPTION
Clearly chamtool.py and chamlog.py have been written for Python 3, else in Python 2:
```
  File "./chamtool.py", line 14
    print(formatString.format(timeString, text), file=sys.stderr)
                                                     ^
SyntaxError: invalid syntax
```

Therefore I fixed the shebang and gave them execution rights while busy at it.