### PR TITLE
udev rules: tell Modem Manager to ignore ChameleonMini

### DIFF
--- a/Driver/98-ChameleonMini.rules
+++ b/Driver/98-ChameleonMini.rules
@@ -1,2 +1,2 @@
 # Rule for ChameleonMini RFID Research tool
-ATTRS{product}=="Chameleon-Mini", SUBSYSTEMS=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="04b2", GROUP="users", MODE="0666", SYMLINK+="chameleon"
+ATTRS{product}=="Chameleon-Mini", SUBSYSTEMS=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="04b2", GROUP="users", MODE="0666", SYMLINK+="chameleon", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
When ChameleonMini is plugged, ModemManager tries automatically to scan it and the device can't be used for a while till ModemManager decides it's not a serial modem.

The proposed patch tells ModemManager to ignore the ChameleonMini
Based on http://linux-tips.com/t/prevent-modem-manager-to-capture-usb-serial-devices/284/2
