### PR TITLE
use -mstrict-X compiler option for smaller/faster code

### DIFF
--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -91,7 +91,7 @@ SRC         += Codec/Codec.c Codec/ISO14443-2A.c Codec/Reader14443-2A.c
 SRC         += Application/MifareUltralight.c Application/MifareClassic.c Application/ISO14443-3A.c Application/Crypto1.c Application/Reader14443A.c
 SRC         += $(LUFA_SRC_USB) $(LUFA_SRC_USBCLASS)
 LUFA_PATH    = ../LUFA
-CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR) -DFLASH_DATA_SIZE=$(FLASH_DATA_SIZE) -DSPM_HELPER_ADDR=$(SPM_HELPER_ADDR) -DBUILD_DATE=$(BUILD_DATE) -DCOMMIT_ID=\"$(COMMIT_ID)\" $(SETTINGS)
+CC_FLAGS     = -mstrict-X -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR) -DFLASH_DATA_SIZE=$(FLASH_DATA_SIZE) -DSPM_HELPER_ADDR=$(SPM_HELPER_ADDR) -DBUILD_DATE=$(BUILD_DATE) -DCOMMIT_ID=\"$(COMMIT_ID)\" $(SETTINGS)
 LD_FLAGS     = -Wl,--section-start=.flashdata=$(FLASH_DATA_ADDR) -Wl,--section-start=.spmhelper=$(SPM_HELPER_ADDR)
 OBJDIR       = Bin
 OBJECT_FILES = 


### PR DESCRIPTION
GCC by default tries to use the X register pair for indexed loads/stores, resulting in suboptimal code (constant register reloads, which are not optimised away across accesses). Using this option forces the compiler to use only Y and Z register pairs for indexed accesses as these are properly supported by hardware, and leave X alone. As a result, this shaves off ~700b off on the latest master build (38538 vs 39220 bytes).

References:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46278
https://gcc.gnu.org/onlinedocs/gcc/AVR-Options.html
