### PR TITLE
chamlog: ensure it works on Python 2 and 3

### DIFF
--- a/Software/chamlog.py
+++ b/Software/chamlog.py
@@ -13,7 +13,7 @@ import datetime
 def verboseLog(text):
     formatString = "[{}] {}"
     timeString = datetime.datetime.utcnow()
-    print(formatString.format(timeString, text), file=sys.stderr)
+    sys.stderr.write(formatString.format(timeString, text) + "\n")
 	
 def formatText(log):
     formatString  = '{timestamp:0>5d} ms <{deltaTimestamp:>+6d} ms>:'


### PR DESCRIPTION
The code was not being parsed correctly on Python 2 due to `print` being a statement and not a function, as in Python 3; ensure that it works good enough for all versions.