### PR TITLE
Add option to fix manufacturer byte on UID_LEFT_(DE/IN)CREMENT on 7-byte UID

### DIFF
--- a/Firmware/Chameleon-Mini/Button.c
+++ b/Firmware/Chameleon-Mini/Button.c
@@ -47,11 +47,17 @@ static void ExecuteButtonAction(ButtonActionEnum ButtonAction)
 
     case BUTTON_ACTION_UID_LEFT_INCREMENT:
     {
+        uint8_t offset = 0;
+#ifdef SUPPORT_UID7_FIX_MANUFACTURER_BYTE
+        if (ActiveConfiguration.UidSize == 7) {
+            offset = 1;
+        }
+#endif
         ApplicationGetUid(UidBuffer);
         bool Carry = 1;
         uint8_t i;
 
-        for (i=0; i<ActiveConfiguration.UidSize; i++) {
+        for (i=offset; i<ActiveConfiguration.UidSize; i++) {
             if (Carry) {
                 if (UidBuffer[i] == 0xFF) {
                     Carry = 1;
@@ -91,11 +97,17 @@ static void ExecuteButtonAction(ButtonActionEnum ButtonAction)
 
     case BUTTON_ACTION_UID_LEFT_DECREMENT:
     {
+        uint8_t offset = 0;
+#ifdef SUPPORT_UID7_FIX_MANUFACTURER_BYTE
+        if (ActiveConfiguration.UidSize == 7) {
+            offset = 1;
+        }
+#endif
         ApplicationGetUid(UidBuffer);
         bool Carry = 1;
         uint8_t i;
 
-        for (i=0; i<ActiveConfiguration.UidSize; i++) {
+        for (i=offset; i<ActiveConfiguration.UidSize; i++) {
             if (Carry) {
                 if (UidBuffer[i] == 0x00) {
                     Carry = 1;

--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -16,6 +16,9 @@ SETTINGS	+= -DCONFIG_ISO14443A_READER_SUPPORT
 #Support magic mode on mifare classic configuration
 SETTINGS	+= -DSUPPORT_MF_CLASSIC_MAGIC_MODE
 
+#Don't touch manufacturer byte with BUTTON_ACTION_UID_LEFT_(DE/IN)CREMENT
+SETTINGS	+= -DSUPPORT_UID7_FIX_MANUFACTURER_BYTE
+
 #Support activating firmware upgrade mode through command-line
 SETTINGS	+= -DSUPPORT_FIRMWARE_UPGRADE
 


### PR DESCRIPTION
For cards with 7-byte UID, the leftmost byte is the manufacturer byte, then the "real" UID so e.g. if you've cards from the same production batch, they'll differ only in e.g. the second and third leftmost bytes.
So this patch skips the manufacturer byte on button actions UID_LEFT_INCREMENT & UID_LEFT_DECREMENT.
Typical example is if you know the uid of one card and try to find the UID of a card from the same installation but with more privileges.
It's still possible to enable the old behavior by removing this line from the Makefile:

```
SETTINGS       += -DSUPPORT_UID7_FIX_MANUFACTURER_BYTE
```
