### PR TITLE
multiline response handling

### DIFF
--- a/Firmware/Chameleon-Mini/Terminal/CommandLine.c
+++ b/Firmware/Chameleon-Mini/Terminal/CommandLine.c
@@ -436,6 +436,7 @@ static void DecodeCommand(void)
     TerminalSendString(pTerminalBuffer);
     TerminalSendStringP(PSTR(OPTIONAL_ANSWER_TRAILER));
   }
+  TerminalSendChar('\0');
 }
 
 void CommandLineInit(void)
@@ -487,6 +488,7 @@ INLINE void Timeout(void)
 		CommandLinePendingTaskTimeout(); // call the function that ends the task
 		CommandLinePendingTaskTimeout = NO_FUNCTION;
 	}
+	TerminalSendChar('\0');
 }
 
 void CommandLineTick(void)
@@ -521,6 +523,7 @@ void CommandLinePendingTaskFinished(CommandStatusIdType ReturnStatusID, char con
 		TerminalSendString(OutMessage);
 	    TerminalSendStringP(PSTR(OPTIONAL_ANSWER_TRAILER));
 	}
+	TerminalSendChar('\0');
 }
 
 void CommandLineAppendData(void const * const Buffer, uint16_t Bytes)
@@ -551,4 +554,5 @@ void CommandLineAppendData(void const * const Buffer, uint16_t Bytes)
     }
 
     TerminalSendStringP(PSTR(OPTIONAL_ANSWER_TRAILER));
+    TerminalSendChar('\0');
 }

--- a/Software/Chameleon/Device.py
+++ b/Software/Chameleon/Device.py
@@ -147,9 +147,16 @@ class Device:
 
     def readResponse(self):
         # Read response to command, if any
-        response = self.serial.readline().decode('ascii').rstrip()
+        timeout = self.serial.timeout
+        self.serial.timeout = 1
+        response = ""
+        tmp = self.serial.read(1)
+        while tmp != b'\0':
+          response += tmp.decode('ascii')
+          tmp = self.serial.read(1)
         self.verboseLog("Response: {}".format(response))
-        return response
+        self.serial.timeout = timeout
+        return response.rstrip()
     
     def execCmd(self, cmd, args=None):
         if (args is None):


### PR DESCRIPTION
This is a first approach to handle multiline responses from Chameleon properly. I first tried to send the EOT character but minicom printed it to screen which has been annoying.

This solution does the following: It sends a NULL-Byte right after a transmission has been finished (minicom ignores this). The chamtool now tries to obtain data until it reads a NULL-Byte. The latter one might look dangerous, but it should work as long as the firmware works. However, I'm not too familiar with efficient python, maybe someone knows how to handle this better?

Another idea would be to send this NULL-Byte before the final "\r\n", maybe this is better?