### PR TITLE
If no ENABLE_EEPROM_SETTINGS is used in MakeFile, a 0 byte eeprom is generated

### DIFF
--- a/Firmware/Chameleon-Mini/Log.c
+++ b/Firmware/Chameleon-Mini/Log.c
@@ -9,7 +9,11 @@ static uint8_t LogMem[LOG_SIZE];
 static uint8_t *LogMemPtr;
 static uint16_t LogMemLeft;
 static uint16_t LogFRAMAddr = FRAM_LOG_START_ADDR;
-static uint8_t EEMEM LogFRAMAddrValid = false;
+#if ENABLE_EEPROM_SETTINGS
+	static uint8_t EEMEM LogFRAMAddrValid = false;
+#else
+	static uint8_t LogFRAMAddrValid = false;
+#endif
 static bool EnableLogSRAMtoFRAM = false;
 LogFuncType CurrentLogFunc;
 
@@ -67,19 +71,24 @@ void LogInit(void)
     LogMemPtr = LogMem;
     LogMemLeft = sizeof(LogMem);
 
+#if ENABLE_EEPROM_SETTINGS
     uint8_t result;
     ReadEEPBlock((uint16_t) &LogFRAMAddrValid, &result, 1);
+#endif
     memset(LogMemPtr, LOG_EMPTY, LOG_SIZE);
+#if ENABLE_EEPROM_SETTINGS
     if (result)
     {
     	MemoryReadBlock(&LogFRAMAddr, FRAM_LOG_ADDR_ADDR, 2);
     } else {
+#endif
     	LogFRAMAddr = FRAM_LOG_START_ADDR;
     	MemoryWriteBlock(&LogFRAMAddr, FRAM_LOG_ADDR_ADDR, 2);
+#if ENABLE_EEPROM_SETTINGS
     	result = true;
     	WriteEEPBlock((uint16_t) &LogFRAMAddrValid, &result, 1);
     }
-
+#endif
     LogEntry(LOG_INFO_SYSTEM_BOOT, NULL, 0);
 }
 

--- a/Firmware/Chameleon-Mini/Settings.c
+++ b/Firmware/Chameleon-Mini/Settings.c
@@ -12,7 +12,11 @@
 #define INDEX_TO_SETTING(I) (I + SETTINGS_FIRST)
 
 SettingsType GlobalSettings;
+#if ENABLE_EEPROM_SETTINGS
 SettingsType EEMEM StoredSettings = {
+#else
+SettingsType StoredSettings = {
+#endif
 	.ActiveSettingIdx = SETTING_TO_INDEX(DEFAULT_SETTING),
 	.ActiveSettingPtr = &GlobalSettings.Settings[SETTING_TO_INDEX(DEFAULT_SETTING)],
 
@@ -30,7 +34,11 @@ SettingsType EEMEM StoredSettings = {
 };
 
 void SettingsLoad(void) {
+#if ENABLE_EEPROM_SETTINGS
 	ReadEEPBlock((uint16_t) &StoredSettings, &GlobalSettings, sizeof(SettingsType));
+#else
+	GlobalSettings = StoredSettings;
+#endif
 }
 
 void SettingsSave(void) {


### PR DESCRIPTION
Without the Makefile setting 
SETTINGS	+= -DENABLE_EEPROM_SETTINGS
The application still reads the EEPROM for default settings and the LogInit function still uses EEPROM.

Due to the worn out EEPROM of my xmega, I wanted to run the application without a single EEPROM read or write.

This branch makes the .eep file has 0 bytes to write and every thing still works. 

The LogInit function is now horrible, can't figure out why there needs to be a EEPROM read and write. but I have no working EEPROM, so I can't test a rewrite.
