### PR TITLE
Upgrade chamlog tool, Decode Mifare DESFire and remove parity bit

### DIFF
--- a/Software/Chameleon/Device.py
+++ b/Software/Chameleon/Device.py
@@ -251,4 +251,7 @@ class Device:
             return self.getSetCmd(self.COMMAND_THRESHOLD, value)
 
     def cmdUpgrade(self):
-        return self.execCmd(self.COMMAND_UPGRADE)
+        # Execute command
+        cmdLine = self.COMMAND_UPGRADE + self.LINE_ENDING
+        self.serial.write(cmdLine.encode('ascii'))
+        return 0

--- a/Software/Chameleon/Device.py
+++ b/Software/Chameleon/Device.py
@@ -21,7 +21,10 @@ class Device:
     COMMAND_RBUTTON = "RBUTTON"
     COMMAND_GREEN_LED = "LEDGREEN"
     COMMAND_RED_LED = "LEDRED"
-    
+    COMMAND_THRESHOLD = "THRESHOLD"
+    COMMAND_UPGRADE = "upgrade"
+
+
     STATUS_CODE_OK = 100
     STATUS_CODE_OK_WITH_TEXT = 101
     STATUS_CODE_WAITING_FOR_XMODEM = 110
@@ -240,3 +243,12 @@ class Device:
             return self.getCmdSuggestions(self.COMMAND_RED_LED)
         else:
             return self.getSetCmd(self.COMMAND_RED_LED, newFunction)
+
+    def cmdThreshold(self, value):
+        if(value == self.SUGGEST_CHAR):
+            return self.getCmdSuggestions(self.COMMAND_THRESHOLD)
+        else:
+            return self.getSetCmd(self.COMMAND_THRESHOLD, value)
+
+    def cmdUpgrade(self):
+        return self.execCmd(self.COMMAND_UPGRADE)

--- a/Software/Chameleon/ISO14443.py
+++ b/Software/Chameleon/ISO14443.py
@@ -68,6 +68,28 @@ class BlockData:
         # PCB
         note += self.type + " "
 
+        # Block number
+        if ((self.type == "IBlock" or self.type == "RBlock") and self.PCB & 0x01):
+            note += "BlkNo:1 "
+
+        # Chaining?
+        if (self.type == "IBlock" and self.PCB & 0x10):
+            note += "Chaining "
+
+        # ACK/NAK? for R-Block
+        if (self.type == "RBlock"):
+            if (self.PCB & 0x10):
+                note += "NAK "
+            else:
+                note += "ACK "
+
+        # DESEL/WTX for SBlock
+        if (self.type == "SBlock"):
+            if (self.PCB & 0x30 == 0x00):
+                note += "DESEL "
+            elif (self.PCB & 0x30 == 0x30):
+                note += "WTX"
+
         # CID
         if (self.CID != None):
             note += "CID:" + hex(self.CID) + " "

--- a/Software/Chameleon/ISO14443.py
+++ b/Software/Chameleon/ISO14443.py
@@ -203,7 +203,6 @@ def parseReader_3(data):
 
     # SELECT Command
     elif (byteCount == 9 and data[0] in ReaderTrafficTypes["SEL"] and data[1] == 0x70):
-        # TODO: distinguish CT+uid012+BCC and uid0123+BCC
         readerCMD = ReaderCMD.SELECT
         note += "SELECT - "
         note += ReaderTrafficTypes["SEL"][data[0]]
@@ -313,8 +312,6 @@ def parseCard_4(data):
         if (hasTC and data[byteNext] & 0xFC == 0x00):
             note += "TC:" + hex(data[byteNext]) + " "
             byteNext += 1
-
-        # TODO: decode historical bytes
 
         # Check CRC_A
         if not CRC_A_check(data):

--- a/Software/Chameleon/ISO14443.py
+++ b/Software/Chameleon/ISO14443.py
@@ -1,10 +1,18 @@
 import binascii
 import crcmod
-
+from enum import Enum
 # Parameters for CRC_A
 CRC_INIT = 0x6363
 POLY = 0x11021
 CRC_A_func = crcmod.mkCrcFun(POLY, initCrc=CRC_INIT, xorOut=0)
+
+
+class ReaderCMD(Enum):
+    NONE = 0
+    RATS = 1
+    PPS  = 2
+
+readerCMD = ReaderCMD.NONE
 
 ReaderTrafficTypes = {
     "SEL":{
@@ -38,8 +46,20 @@ ReaderTrafficTypes = {
 CardTrafficTypes = {
     "SAK":{
         0x04: "UID NOT Complete ",
+        0x24: "UID NOT Complete, PICC compliant with 14443-4",
         0x20: "UID complete, PICC compliant with 14443-4 ",
         0x00: "UID complete, PICC NOT compliant with 14443-4"
+    },
+    "FSCI": {
+        0x0: "FSCC:16 ",
+        0x1: "FSC:24 ",
+        0x2: "FSC:32 ",
+        0x3: "FSC:40 ",
+        0x4: "FSC:48 ",
+        0x5: "FSC:64 ",
+        0x6: "FSC:96 ",
+        0x7: "FSC:128 ",
+        0x8: "FSC:256 "
     }
 }
 
@@ -58,66 +78,77 @@ def CRC_A_check(data):
     else:
         return False
 
-def parseReader(data):
+def parseReader_3(data):
     byteCount = len(data)
     note = ""
 
     # short frame commands
     if (byteCount == 1 and data[0] in ReaderTrafficTypes["SHORTFRAME"]):
-            note += ReaderTrafficTypes["SHORTFRAME"][data[0]]
+        note += ReaderTrafficTypes["SHORTFRAME"][data[0]]
 
     # ANTICOLLISION command
-    elif (byteCount<9 and byteCount > 1 and data[0] in ReaderTrafficTypes["SEL"] and data[1] & 0x88 == 0 ):
+    elif (byteCount < 9 and byteCount > 1 and data[0] in ReaderTrafficTypes["SEL"] and data[1] & 0x88 == 0):
         note += "ATCOLI - "
         note += ReaderTrafficTypes["SEL"][data[0]]
         # note += "UID_CLn:" + binascii.hexlify(data[2:7]).decode() + " "
         # note += str((data[1] >> 4) & 0x0f) + "bytes + " + str(data[1] & 0x0f) + "bits "
 
     # SELECT Command
-    elif (byteCount== 9 and data[0] in ReaderTrafficTypes["SEL"] and data[1] == 0x70):
+    elif (byteCount == 9 and data[0] in ReaderTrafficTypes["SEL"] and data[1] == 0x70):
         # TODO: distinguish CT+uid012+BCC and uid0123+BCC
         note += "SELECT - "
         note += ReaderTrafficTypes["SEL"][data[0]]
         note += "UID_CLn:" + binascii.hexlify(data[2:6]).decode() + " "
         # Check CRC for SELECT
-        if(not CRC_A_check(data)):
-            note+=" WRONG CRC "
+        if (not CRC_A_check(data)):
+            note += " WRONG CRC "
         # note += "7bytes + 0bits "
         # note += "CRC_A:"+data[7:9]
     # HALT Command
     elif (byteCount == 4 and data[0] == 0x50 and data[1] == 0x00):
         note += "HALT"
+
+    return note
+
+def parseReader_4(data):
+    byteCount = len(data)
+    note = ""
+
     # RATS
-    elif (byteCount == 4 and data[0] == 0xe0 and ((data[1] & 0x0f) < 15) and ((data[1] & 0xf0 >> 8) in ReaderTrafficTypes["FSDI"])):
+    if (byteCount == 4 and data[0] == 0xe0 and ((data[1] & 0x0f) < 15) and (
+            (data[1] & 0xf0 >> 8) in ReaderTrafficTypes["FSDI"])):
         note += "RATS - "
-        note += ReaderTrafficTypes["FSDI"][data[1]>>8]
-        note += "CID:" + str(data[1]&0x0f) + " "
-        if(not CRC_A_check(data)):
-            note+=" WRONG CRC "
+        note += ReaderTrafficTypes["FSDI"][data[1] >> 8]
+        note += "CID:" + str(data[1] & 0x0f) + " "
+        if (not CRC_A_check(data)):
+            note += " WRONG CRC "
+        else:
+            readerCMD = ReaderCMD.RATS
+
     # PPS Protocol and parameter selection request
     # PSS0 only
-    elif (byteCount == 4 and (data[0]&0xf0 == 0xd0) and (data[1] == 0x01)):
+    elif (byteCount == 4 and (data[0] & 0xf0 == 0xd0) and (data[1] == 0x01)):
         note += "PSS0 - "
-        note += "CID:"+str(data[1]&0x0f) + " "
+        note += "CID:" + str(data[1] & 0x0f) + " "
+        readerCMD = ReaderCMD.PPS
     # PSS0+1
-    elif (byteCount == 5 and (data[0]&0xf0 == 0xd0) and (data[1] == 0x11) and (data[2]&0xf0 == 0x00)):
+    elif (byteCount == 5 and (data[0] & 0xf0 == 0xd0) and (data[1] == 0x11) and (data[2] & 0xf0 == 0x00)):
         note += "PSS0+1 - "
-        note += "CID:"+str(data[1]&0x0f) + " "
-        note += "DSI:"+str(pow(2,(data[2]>>2)&0x03)) + " "
-        note += "DRI:"+str(pow(2,data[2]&0x03)) + " "
-    # BLOCK S-block PCB DESELECT 
+        note += "CID:" + str(data[1] & 0x0f) + " "
+        note += "DSI:" + str(pow(2, (data[2] >> 2) & 0x03)) + " "
+        note += "DRI:" + str(pow(2, data[2] & 0x03)) + " "
+    # BLOCK S-block PCB DESELECT
     # Without CID
     elif (byteCount == 3 and data[0] == 0xc2):
         note += "DESEL"
     # With CID
-    elif (byteCount == 4 and data[0] == 0xca and data[1]&0x30 == 0x00):
+    elif (byteCount == 4 and data[0] == 0xca and data[1] & 0x30 == 0x00):
         note += "DESEL - "
-        note += "CID:"+ str(data[1]&0x0f) + " "
-        
+        note += "CID:" + str(data[1] & 0x0f) + " "
+
     return note
 
-def parseCard(data):
-
+def parseCard_3(data):
     byteCount = len(data)
     note = ""
 
@@ -126,7 +157,7 @@ def parseCard(data):
         note += "ATQA - "
         note += binascii.hexlify(data).decode()
     # SAK
-    elif (byteCount == 3 and (data[0] & (~0x24)) == 0x00):
+    elif (byteCount == 3 and ((data[0] & (0x24)) in CardTrafficTypes["SAK"])):
         note += "SAK - "
         note += CardTrafficTypes["SAK"][(data[2] & 0x24)]
         if not CRC_A_check(data):
@@ -137,4 +168,54 @@ def parseCard(data):
 
     return note
 
-    pass
+def parseCard_4(data):
+    byteCount = len(data)
+    note = ""
+
+    # ATS
+    # TL + T0 + TA + TB + TC + T1 ... + CRC
+    # TL: length without CRC
+    # ATS without data
+    if(byteCount == 3 and data[0] == (byteCount-2)):
+        note += "ATS - NO DATA"
+    # ATS with data mush have T0, T0 b8=0
+    elif (byteCount > 3 and data[0] == (byteCount-2)
+            and data[1] & 0x80 == 0x00
+            and data[1] & 0x0f in CardTrafficTypes["FSCI"]):
+        # Decode T0
+        hasTA = data[1] & 0x10
+        hasTB = data[1] & 0x20
+        hasTC = data[1] & 0x40
+        note += CardTrafficTypes["FSCI"][data[1] & 0x0f]
+
+        # Which byte to decode next
+        byteNext = 2        # T0 Decoded, next is TA/TB/TC
+        #  TA b4=0
+        if (hasTA and data[byteNext] & 0x08 == 0x00):
+            note += "TA:" + hex(data[byteNext]) + " "
+            byteNext += 1
+
+        if (hasTB):
+            note += "TB:" + hex(data[byteNext]) + " "
+            byteNext += 1
+
+        # TC b3-8=0
+        if (hasTC and data[byteNext] & 0xFC == 0x00):
+            note += "TC:" + hex(data[byteNext]) + " "
+            byteNext += 1
+
+        # TODO: decode historical bytes
+
+        # Check CRC_A
+        if not CRC_A_check(data):
+            note += " WRONG CRC "
+
+    elif ():
+        pass
+    return note
+
+def parseReader(data):
+    return parseReader_3(data) + parseReader_4(data)
+
+def parseCard(data):
+    return parseCard_3(data) + parseCard_4(data)

--- a/Software/Chameleon/ISO14443.py
+++ b/Software/Chameleon/ISO14443.py
@@ -1,0 +1,87 @@
+import binascii
+
+ReaderTrafficTypes = {
+    "SEL":{
+        0x93: "SEL_CL1 ",
+        0x95: "SEL_CL2 ",
+        0x97: "SEL_CL3 ",
+    },
+    # 1 byte commands
+    "SHORTFRAME": {
+        0x26: "REQA",
+        0x52: "WUPA",
+        0x35: "Optional Timeslot Method",
+        # 40 - 4F Proprietary
+        # 78 - 7F proprietary
+        # Other RFU
+    },
+    "FSDI":{
+        0x0: "FSD:16 ",
+        0x1: "FSD:24 ",
+        0x2: "FSD:32 ",
+        0x3: "FSD:40 ",
+        0x4: "FSD:48 ",
+        0x5: "FSD:64 ",
+        0x6: "FSD:96 ",
+        0x7: "FSD:128 ",
+        0x8: "FSD:256 "
+    },
+}
+
+CardTrafficTypes = {
+
+}
+def parseReader(data):
+    byteCount = len(data)
+    note = ""
+
+    # short frame commands
+    if (byteCount == 1 and data[0] in ReaderTrafficTypes["SHORTFRAME"]):
+            note += ReaderTrafficTypes["SHORTFRAME"][data[0]]
+
+    # ANTICOLLISION command
+    elif (byteCount<9 and byteCount > 1 and data[0] in ReaderTrafficTypes["SEL"] and data[1] & 0x88 == 0 ):
+        note += "ATCOLI - "
+        note += ReaderTrafficTypes["SEL"][data[0]]
+        # note += "UID_CLn:" + binascii.hexlify(data[2:7]).decode() + " "
+        # note += str((data[1] >> 4) & 0x0f) + "bytes + " + str(data[1] & 0x0f) + "bits "
+
+    # SELECT Command
+    elif (byteCount== 9 and data[0] in ReaderTrafficTypes["SEL"] and data[1] == 0x70):
+        note += "SELECT - "
+        note += ReaderTrafficTypes["SEL"][data[0]]
+        note += "UID_CLn:" + binascii.hexlify(data[2:7]).decode() + " "
+        # note += "7bytes + 0bits "
+        # note += "CRC_A:"+data[8]
+    # HALT Command
+    elif (byteCount == 4 and data[0] == 0x50 and data[1] == 0x00):
+        note += "HALT"
+    # RATS
+    elif (byteCount == 4 and data[0] == 0xe0 and ((data[1] & 0x0f) < 15) and ((data[1] & 0xf0 >> 8) in ReaderTrafficTypes["FSDI"])):
+        note += "RATS - "
+        note += ReaderTrafficTypes["FSDI"][data[1]>>8]
+        note += "CID:" + str(data[1]&0x0f) + " "
+    # PPS Protocol and parameter selection request
+    # PSS0 only
+    elif (byteCount == 4 and (data[0]&0xf0 == 0xd0) and (data[1] == 0x01)):
+        note += "PSS0 - "
+        note += "CID:"+str(data[1]&0x0f) + " "
+    # PSS0+1
+    elif (byteCount == 5 and (data[0]&0xf0 == 0xd0) and (data[1] == 0x11) and (data[2]&0xf0 == 0x00)):
+        note += "PSS0+1 - "
+        note += "CID:"+str(data[1]&0x0f) + " "
+        note += "DSI:"+str(pow(2,(data[2]>>2)&0x03)) + " "
+        note += "DRI:"+str(pow(2,data[2]&0x03)) + " "
+    # BLOCK S-block PCB DESELECT 
+    # Without CID
+    elif (byteCount == 3 and data[0] == 0xc2):
+        note += "DESEL"
+    # With CID
+    elif (byteCount == 4 and data[0] == 0xca and data[1]&0x30 == 0x00):
+        note += "DESEL - "
+        note += "CID:"+ str(data[1]&0x0f) + " "
+        
+    return note
+
+def parseCard(data):
+    pass

--- a/Software/Chameleon/Log.py
+++ b/Software/Chameleon/Log.py
@@ -3,6 +3,7 @@
 import struct
 import binascii
 import math
+import Chameleon.ISO14443 as iso14443_3
 
 def checkParityBit(data):
     byteCount = len(data)
@@ -96,7 +97,7 @@ eventTypes = {
 TIMESTAMP_MAX = 65536
 eventTypes = { i : ({'name': 'UNKNOWN', 'decoder': binaryDecoder} if i not in eventTypes.keys() else eventTypes[i]) for i in range(256) }
 
-def parseBinary(binaryStream):
+def parseBinary(binaryStream, decode=False):
     log = []
     
     # Completely read file contents and process them byte by byte
@@ -135,13 +136,20 @@ def parseBinary(binaryStream):
         if (deltaTimestamp < 0):
             deltaTimestamp += TIMESTAMP_MAX;
 
+        note = ""
+        # If we need to decode the data
+        if (decode):
+            # Decode the data from Reader
+            if(event == 0x44 or event == 0x45):
+                note = iso14443_3.parseReader(binascii.a2b_hex(logData))
         # Create log entry as dict and append it to event list
         logEntry = {
             'eventName': eventTypes[event]['name'],
             'dataLength': dataLength,
             'timestamp': timestamp,
             'deltaTimestamp': deltaTimestamp,
-            'data': logData
+            'data': logData,
+            'note': note
         }
         
         log.append(logEntry)

--- a/Software/Chameleon/Log.py
+++ b/Software/Chameleon/Log.py
@@ -138,7 +138,7 @@ def parseBinary(binaryStream, decoder=None):
 
         note = ""
         # If we need to decode the data and paritybit check success
-        if (decoder!=None and logData[-1] != '!'):
+        if (decoder!=None and len(logData) >0 and logData[-1] != '!'):
             # Decode the data from Reader
             if(event == 0x44 or event == 0x45):
                 note = iso14443_3.parseReader(binascii.a2b_hex(logData), decoder)

--- a/Software/Chameleon/Log.py
+++ b/Software/Chameleon/Log.py
@@ -97,7 +97,7 @@ eventTypes = {
 TIMESTAMP_MAX = 65536
 eventTypes = { i : ({'name': 'UNKNOWN', 'decoder': binaryDecoder} if i not in eventTypes.keys() else eventTypes[i]) for i in range(256) }
 
-def parseBinary(binaryStream, decode=False):
+def parseBinary(binaryStream, decoder=None):
     log = []
     
     # Completely read file contents and process them byte by byte
@@ -138,12 +138,12 @@ def parseBinary(binaryStream, decode=False):
 
         note = ""
         # If we need to decode the data and paritybit check success
-        if (decode and logData[-1] != '!'):
+        if (decoder!=None and logData[-1] != '!'):
             # Decode the data from Reader
             if(event == 0x44 or event == 0x45):
-                note = iso14443_3.parseReader(binascii.a2b_hex(logData))
+                note = iso14443_3.parseReader(binascii.a2b_hex(logData), decoder)
             elif (event == 0x46 or event == 0x47):
-                note = iso14443_3.parseCard(binascii.a2b_hex(logData))
+                note = iso14443_3.parseCard(binascii.a2b_hex(logData), decoder)
 
         # Create log entry as dict and append it to event list
         logEntry = {

--- a/Software/Chameleon/Log.py
+++ b/Software/Chameleon/Log.py
@@ -137,13 +137,14 @@ def parseBinary(binaryStream, decode=False):
             deltaTimestamp += TIMESTAMP_MAX;
 
         note = ""
-        # If we need to decode the data
-        if (decode):
+        # If we need to decode the data and paritybit check success
+        if (decode and logData[-1] != '!'):
             # Decode the data from Reader
             if(event == 0x44 or event == 0x45):
                 note = iso14443_3.parseReader(binascii.a2b_hex(logData))
             elif (event == 0x46 or event == 0x47):
                 note = iso14443_3.parseCard(binascii.a2b_hex(logData))
+
         # Create log entry as dict and append it to event list
         logEntry = {
             'eventName': eventTypes[event]['name'],

--- a/Software/Chameleon/Log.py
+++ b/Software/Chameleon/Log.py
@@ -142,6 +142,8 @@ def parseBinary(binaryStream, decode=False):
             # Decode the data from Reader
             if(event == 0x44 or event == 0x45):
                 note = iso14443_3.parseReader(binascii.a2b_hex(logData))
+            elif (event == 0x46 or event == 0x47):
+                note = iso14443_3.parseCard(binascii.a2b_hex(logData))
         # Create log entry as dict and append it to event list
         logEntry = {
             'eventName': eventTypes[event]['name'],

--- a/Software/Chameleon/Log.py
+++ b/Software/Chameleon/Log.py
@@ -2,6 +2,40 @@
 
 import struct
 import binascii
+import math
+
+def checkParityBit(data):
+    byteCount = len(data)
+    # Short frame, no parityBit
+    if (byteCount == 1):
+        return (True, data)
+
+    # 9 bit is a group, validate bit count is calculated below
+    bitCount = int((byteCount*8)/9) * 9
+    parsedData = bytearray(int(bitCount/9))
+
+    oneCounter = 0            # Counter for count ones in a byte
+    for i in range(0, bitCount):
+        # Get bit i in data
+        byteIndex = math.floor(i/8)
+        bitIndex = i % 8
+        bit = (data[byteIndex] >> bitIndex) & 0x01
+
+        # Check parityBit
+        # Current bit is parityBit
+        if(i % 9 == 8):
+            # Even number of ones in current byte
+            if(oneCounter % 2 and bit == 1):
+                return (False, data)
+            # Odd number of ones in current byte
+            elif((not oneCounter % 2) and bit == 0):
+                return (False, data)
+            oneCounter = 0
+        # Current bit is normal bit
+        else:
+            oneCounter += bit
+            parsedData[int(i/9)] |= bit << (i%9)
+    return (True, parsedData)
 
 def noDecoder(data):
     return ""
@@ -11,6 +45,13 @@ def textDecoder(data):
 
 def binaryDecoder(data):
     return binascii.hexlify(data).decode()
+
+def binaryParityDecoder(data):
+    isValid, checkedData = checkParityBit(data)
+    if(isValid):
+        return binascii.hexlify(checkedData).decode()
+    else:
+        return binascii.hexlify(checkedData).decode()+"!"
 
 eventTypes = {
     0x00: { 'name': 'EMPTY',          'decoder': noDecoder },
@@ -24,6 +65,12 @@ eventTypes = {
     0x41: { 'name': 'CODEC TX',       'decoder': binaryDecoder },
     0x42: { 'name': 'CODEC RX W/PARITY', 'decoder': binaryDecoder },
     0x43: { 'name': 'CODEC TX W/PARITY', 'decoder': binaryDecoder },
+
+    0x44: { 'name': 'CODEC RX SNI READER',          'decoder': binaryDecoder },
+    0x45: { 'name': 'CODEC RX SNI READER W/PARITY', 'decoder': binaryParityDecoder },
+    0x46: { 'name': 'CODEC RX SNI CARD',            'decoder': binaryDecoder },
+    0x47: { 'name': 'CODEC RX SNI CARD W/PARITY',   'decoder': binaryParityDecoder },
+   
 
     0x80: { 'name': 'APP READ',       'decoder': binaryDecoder },
     0x81: { 'name': 'APP WRITE',      'decoder': binaryDecoder },

--- a/Software/Chameleon/MFDESFire.py
+++ b/Software/Chameleon/MFDESFire.py
@@ -327,6 +327,7 @@ MFDESFireCMDTypes = {
 
 # Commands need to use additional frame
 MFDESFireAFCMD = {
+    0xBD : {"name": "ReadData ",         "AFReaderDecoder": decodeDummy,         "AFCardDecoder": decodeData},
     0xAA : {"name": "AuthAES ",          "AFReaderDecoder":decodeAuthAESAF,     "AFCardDecoder": decodeCardAuthAESAF},
     0x0A : {"name": "Auth3DES ",         "AFReaderDecoder":decodeAuth3DESAF,    "AFCardDecoder": decodeCardAuth3DESAF},
 

--- a/Software/Chameleon/MFDESFire.py
+++ b/Software/Chameleon/MFDESFire.py
@@ -27,11 +27,26 @@ StatusCode = {
     0xF0 : "FILE_NOT_FOUND",
     0xF1 : "ERR_FILE_INTEGRITY"
 }
+# Create APP CMD
+def decodeCreateAPP(data):
+    note = ""
+    if len(data) == 6:
+        note += "AID:0x"+hexlify(data[1:4]).decode() + " "
+        note += "KeySett:"+hex(data[4]) + " "
+        note += "NumOfKeys:"+hex(data[5]) + " "
+    else:
+        note += strFail
+    return note
 
+def decodeDelAPP(data):
+    if len(data) == 4:
+         return "AID:0x"+hexlify(data[1:]).decode()
+    else:
+        return strFail
 
 def decodeSelectAPP(data):
     if len(data) == 4:
-        return "AID: 0x"+ hexlify(data[1:4]).decode()
+        return "AID:0x"+ hexlify(data[1:4]).decode()
     else:
         return strFail
 
@@ -157,17 +172,25 @@ def decodeDummy(data):
 
 
 MFDESFireCMDTypes = {
+    # PICC Level Commands, GetVersion not decoded, please refer to datasheet for the meaning of resp
+    0xCA : {"name": "CreateApp",        "CMDdecoder":decodeCreateAPP,       "RespDecoder":   decodeDummy},
+    0xDA : {"name": "DelApp",           "CMDdecoder":decodeDelAPP,          "RespDecoder":   decodeDummy},
     0x5A : {"name": "SelectApp ",       "CMDdecoder":decodeSelectAPP,       "RespDecoder":   decodeDummy},
     0x6A : {"name": "GetAPPID ",        "CMDdecoder":decodeGetAPPID,        "RespDecoder":   decodeRespGetAPPID},
+    0xFC : {"name": "FormatPICC",       "CMDdecoder":decodeDummy,           "RespDecoder":   decodeDummy},
+    0x60 : {"name": "GetVersion",       "CMDdecoder":decodeDummy,           "RespDecoder":   decodeDummy},
+    # Data Manipulation Commands
     0xBD : {"name": "ReadData ",        "CMDdecoder":decodeReadData,        "RespDecoder":   decodeRespReadData},
-    0xAF : {"name": "AdditionalFrame ", "CMDdecoder":decodeAdiFrame,        "RespDecoder":   decodeRespAdiFrame},
     # Security Related CMD
     0xAA : {"name": "AuthAES ",         "CMDdecoder": decodeAuthAES, "RespDecoder": decodeRespAuthAES},
     0x0A : {"name": "Auth3DES",         "CMDdecoder": decodeAuth3DES, "RespDecoder": decodeRespAuth3DES},
     0x54 : {"name": "ChangeKeySettings ","CMDdecoder":decodeChangeKeySettings,"respDecoder": decodeDummy},
     0x45 : {"name": "GetKeySettings ",  "CMDdecoder":decodeDummy,           "RespDecoder":   decodeRespGetKeySettings},
     0xC4 : {"name": "ChangeKey ",       "CMDdecoder":decodeChangeKey,       "RespDecoder":   decodeDummy},
-    0x64 : {"name": "GetKeyVersion ",   "CMDdecoder":decodeGetKeyVersion,   "RespDecoder":   decodeRespGetKeyVersion}
+    0x64 : {"name": "GetKeyVersion ",   "CMDdecoder":decodeGetKeyVersion,   "RespDecoder":   decodeRespGetKeyVersion},
+
+    # Additional Frame
+    0xAF: {"name": "AdditionalFrame ", "CMDdecoder": decodeAdiFrame, "RespDecoder": decodeRespAdiFrame},
 
 }
 

--- a/Software/Chameleon/MFDESFire.py
+++ b/Software/Chameleon/MFDESFire.py
@@ -194,7 +194,7 @@ def decodeData(data):
 # Application Level Commands
 ###########################
 def decodeRespGetFileIDs(data):
-    if len(data) == 4:
+    if len(data) > 0:
         return "FIDs:0x"+hexlify(data[1:]).decode()
     else:
         return strFail

--- a/Software/Chameleon/MFDESFire.py
+++ b/Software/Chameleon/MFDESFire.py
@@ -65,7 +65,7 @@ def decodeRespGetAPPID (data):
     dataLen = len(data)
 
     for i in range (0,int((dataLen-1)/3)):
-        note += "0x"+hexlify(data[3*i: 3*(i+1)]).decode()+"|"
+        note += "0x"+hexlify(data[1+3*i: 1+3*(i+1)]).decode()+"|"
 
     return note
 ##############################

--- a/Software/Chameleon/MFDESFire.py
+++ b/Software/Chameleon/MFDESFire.py
@@ -1,0 +1,113 @@
+from Chameleon.utils import TrafficSource
+from binascii import hexlify
+
+lastCMD = 0x00
+
+StatusCode = {
+    0x00 : "OPERATION_OK",
+    0x0C : "NO_CHANGES",
+    0x0E : "ERR_OUT_OF_EEPROM",
+    0x1C : "ILLEGAL_CMD_CODE",
+    0x1E : "ERR_INTEGRITY",
+    0x40 : "NO_SUCH_KEY",
+    0x7E : "ERR_LENGTH",
+    0x9D : "PERMISSION_DENIED",
+    0x9E : "ERR_PARAMETER",
+    0xA0 : "APP_NOT_FOUND",
+    0xA1 : "ERR_APP_INTEGRITY",
+    0xAE : "ERR_AUTH",
+    0xAF : "ADDITIONAL_FRAME",
+    0xBE : "ERR_BOUNDARY",
+    0xC1 : "ERR_PICC_INTEGRITY",
+    0xCA : "CMD_ABORTED",
+    0xCD : "ERR_PICC_DISABLED",
+    0xCE : "ERR_COUNT",
+    0xDE : "ERR_DUPLICATE",
+    0xEE : "ERR_EEPROM",
+    0xF0 : "FILE_NOT_FOUND",
+    0xF1 : "ERR_FILE_INTEGRITY"
+}
+
+
+def decodeSelectAPP(data):
+    if len(data) == 4:
+        return "AID: 0x"+ hexlify(data[1:4]).decode()
+    else:
+        return "Decode Fail"
+
+def decodeGetAPPID(data):
+    if len(data) == 1:
+        return ""
+    else:
+        return "Decode Fail"
+
+def decodeRespGetAPPID (data):
+    note = "APPIDs: |"
+    dataLen = len(data)
+
+    for i in range (0,int((dataLen-1)/3)):
+        note += "0x"+hexlify(data[3*i: 3*(i+1)]).decode()+"|"
+
+    return note
+
+
+def decodeAuthAES(data):
+    if len(data) == 2:
+        return "KeyNo:"+hex(data[1])
+    else:
+        return "Decode Fail"
+
+def decodeRespAuthAES(data):
+    return ""
+
+
+def decodeReadData(data):
+    if len(data) == 8:
+        fileNo = data[1]
+        offSet = data[2:5]
+        length = data[5:8]
+        return "FileNo:"+hex(fileNo) + " OffSet:0x"+hexlify(offSet).decode() + " len:0x"+hexlify(length).decode()
+    else:
+        return "Decode Fail"
+
+def decodeRespReadData(data):
+    return "Data:0x"+hexlify(data[1:]).decode()
+
+def decodeAdiFrame(data):
+    return ""
+
+def decodeRespAdiFrame(data):
+    return ""
+
+def decodeDummy(data):
+    return ""
+
+MFDESFireCMDTypes = {
+    0x5A : {"name": "SelectApp ",       "CMDdecoder":decodeSelectAPP,       "RespDecoder":   decodeDummy},
+    0x6A : {"name": "GetAPPID ",        "CMDdecoder":decodeGetAPPID,        "RespDecoder":   decodeRespGetAPPID},
+    0xAA : {"name": "AuthAES ",         "CMDdecoder":decodeAuthAES,         "RespDecoder":   decodeRespAuthAES},
+    0xBD : {"name": "ReadData ",        "CMDdecoder":decodeReadData,        "RespDecoder":   decodeRespReadData},
+    0xAF : {"name": "AdditionalFrame",  "CMDdecoder":decodeAdiFrame,        "RespDecoder":   decodeRespAdiFrame}
+}
+
+
+def MFDESFireDecode(data, source):
+    note = ""
+    global lastCMD
+    if (source == TrafficSource.Reader):
+        cmd = data[0]
+        if cmd in MFDESFireCMDTypes :
+            lastCMD = cmd
+            note += "CMD:" + MFDESFireCMDTypes[cmd]["name"]
+            note += MFDESFireCMDTypes[cmd]["CMDdecoder"](data)
+
+    elif (source == TrafficSource.Card):
+        status = data[0]
+        # Decode status code
+        if status in StatusCode:
+            note += StatusCode[status] + " "
+        # If status Ok, decode data
+        if status == 0x00 and lastCMD in MFDESFireCMDTypes:
+            note += MFDESFireCMDTypes[lastCMD]["RespDecoder"](data)
+
+    return note

--- a/Software/Chameleon/utils.py
+++ b/Software/Chameleon/utils.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class TrafficSource(Enum):
+    Reader = 0
+    Card = 1

--- a/Software/chamlog.py
+++ b/Software/chamlog.py
@@ -19,11 +19,12 @@ def verboseLog(text):
 	
 def formatText(log):
     formatString  = '{timestamp:0>5d} ms <{deltaTimestamp:>+6d} ms>:'
-    formatString += '{eventName:<28} ({dataLength:<3} bytes)\t[{data:<20}]\t{note}\n'
-    text = ''
-    
-    for logEntry in log:
+    formatString += '{eventName:<28} ({dataLength:<3} bytes) [{data:<20}] ' \
+                    '\033[94m {note} \x1b[0m \n'
 
+    text = ''
+
+    for logEntry in log:
         text += formatString.format(**logEntry)
 
     return text

--- a/Software/chamlog.py
+++ b/Software/chamlog.py
@@ -58,6 +58,7 @@ def main():
     else:
         verboseFunc = None
 
+    print("\nNote: If parityBit check failed, '!' is appended to the decoded data and raw data with parity bit is displayed.\n")
     if (args.live):
         # Live logging mode
         if (args.port is not None):

--- a/Software/chamlog.py
+++ b/Software/chamlog.py
@@ -11,6 +11,7 @@ import json
 import Chameleon
 import io
 import datetime
+from Chameleon.ISO14443 import CardTypesMap
 
 def verboseLog(text):
     formatString = "[{}] {}"
@@ -48,7 +49,7 @@ def main():
     
     argParser.add_argument("-t", "--type", choices=outputTypes.keys(), default='text',
                             help="specifies output type")
-    argParser.add_argument("-d", "--decode", dest="decode", action='store_true', default=False)
+    argParser.add_argument("-d", "--decode", dest="decode", choices=CardTypesMap.keys(), default=None, help="Decode the sniffed traffic and application data with a decoder")
     argParser.add_argument("-l", "--live", dest="live", action='store_true', help="Use live logging capabilities of Chameleon")
     argParser.add_argument("-c", "--clear", dest="clear", action='store_true', help="Clear Chameleon's log memory when using -p")
     argParser.add_argument("-m", "--mode", dest="mode", metavar="LOGMODE", help="Additionally set Chameleon's log mode after reading it's memory")

--- a/Software/chamlog.py
+++ b/Software/chamlog.py
@@ -19,10 +19,11 @@ def verboseLog(text):
 	
 def formatText(log):
     formatString  = '{timestamp:0>5d} ms <{deltaTimestamp:>+6d} ms>:'
-    formatString += '{eventName:<16} ({dataLength:<3} bytes) [{data}]\n'
+    formatString += '{eventName:<28} ({dataLength:<3} bytes)\t[{data:<20}]\t{note}\n'
     text = ''
     
     for logEntry in log:
+
         text += formatString.format(**logEntry)
 
     return text
@@ -46,6 +47,7 @@ def main():
     
     argParser.add_argument("-t", "--type", choices=outputTypes.keys(), default='text',
                             help="specifies output type")
+    argParser.add_argument("-d", "--decode", dest="decode", action='store_true', default=False)
     argParser.add_argument("-l", "--live", dest="live", action='store_true', help="Use live logging capabilities of Chameleon")
     argParser.add_argument("-c", "--clear", dest="clear", action='store_true', help="Clear Chameleon's log memory when using -p")
     argParser.add_argument("-m", "--mode", dest="mode", metavar="LOGMODE", help="Additionally set Chameleon's log mode after reading it's memory")
@@ -69,7 +71,7 @@ def main():
 
                 while True:
                     stream = io.BytesIO(chameleon.read())
-                    log = Chameleon.Log.parseBinary(stream)
+                    log = Chameleon.Log.parseBinary(stream, args.decode)
                     if (len(log) > 0):
                         print(outputTypes[args.type](log))
       
@@ -95,7 +97,7 @@ def main():
                 sys.exit(2)
                 
         # Parse actual logfile
-        log = Chameleon.Log.parseBinary(handle)
+        log = Chameleon.Log.parseBinary(handle, args.decode)
 
         # Print to console using chosen output type
         print(outputTypes[args.type](log))

--- a/Software/chamtool.py
+++ b/Software/chamtool.py
@@ -119,7 +119,21 @@ def cmdRedLED(chameleon, arg):
             return "Red LED function has been set to {}".format(chameleon.cmdRedLED()['response'])
         else:
             return "Setting red LED function to {} failed: {}".format(arg, result['statusText'])
-        
+
+def cmdThreshold(chameleon, arg):
+    result = chameleon.cmdThreshold(arg)
+
+    if (arg is None):
+        return "Current threshold is: {}".format(result['response'])
+    else:
+        if (result['statusCode'] in chameleon.STATUS_CODES_SUCCESS):
+            return "Threshold have been set to {}".format(arg)
+        else:
+            return "Setting threshold faled: {}".format(arg, result['statusText'])
+
+def cmdUpgrade(chameleon, arg):
+    result = chameleon.cmdUpgrade()
+    return ""
 # Custom class for argparse
 class CmdListAction(argparse.Action):
     def __init__(self, option_strings, dest, default=False, required=False,
@@ -154,6 +168,9 @@ def main():
     cmdArgGroup.add_argument("-rb",  "--rbutton",    dest="rbutton",     action=CmdListAction, metavar="ACTION", nargs='?', help="retrieve or set the current right button action")
     cmdArgGroup.add_argument("-gl",  "--gled",       dest="gled",        action=CmdListAction, metavar="FUNCTION", nargs='?', help="retrieve or set the current green led function")
     cmdArgGroup.add_argument("-rl",  "--rled",       dest="rled",        action=CmdListAction, metavar="FUNCTION", nargs='?', help="retrieve or set the current red led function")
+    cmdArgGroup.add_argument("-th",  "--threshold",  dest="threshold",   action=CmdListAction, nargs='?', help="retrieve or set the threshold")
+    cmdArgGroup.add_argument("-ug",  "--upgrade",    dest="upgrade",     action=CmdListAction, nargs=0,   help="set the micro Controller to upgrade mode")
+
     args = argParser.parse_args()
     
     if (args.verbose):
@@ -179,6 +196,8 @@ def main():
                 "rbutton"   : cmdRButton,
                 "gled"      : cmdGreenLED,
                 "rled"      : cmdRedLED,
+                "threshold" : cmdThreshold,
+                "upgrade"   : cmdUpgrade,
             }
 
             if hasattr(args, "cmdList"):

--- a/Software/chamtool.py
+++ b/Software/chamtool.py
@@ -68,6 +68,17 @@ def cmdLog(chameleon, arg):
         bytesReceived = chameleon.cmdDownloadLog(fileHandle)
         return "{} Bytes successfully written to {}".format(bytesReceived, arg)
 
+def cmdLogMode(chameleon, arg):
+    result = chameleon.cmdLogMode(arg)
+
+    if (arg is None):
+        return "Current logmode is: {}".format(result['response'])
+    else:
+        if (result['statusCode'] in chameleon.STATUS_CODES_SUCCESS):
+            return "logmode have been set to {}".format(arg)
+        else:
+            return "Setting logmode failed: {}".format(arg, result['statusText'])
+
 def cmdLButton(chameleon, arg):
     result = chameleon.cmdLButton(arg)
     
@@ -129,7 +140,7 @@ def cmdThreshold(chameleon, arg):
         if (result['statusCode'] in chameleon.STATUS_CODES_SUCCESS):
             return "Threshold have been set to {}".format(arg)
         else:
-            return "Setting threshold faled: {}".format(arg, result['statusText'])
+            return "Setting threshold failed: {}".format(arg, result['statusText'])
 
 def cmdUpgrade(chameleon, arg):
     result = chameleon.cmdUpgrade()
@@ -164,6 +175,7 @@ def main():
     cmdArgGroup.add_argument("-s",  "--setting",     dest="setting",     action=CmdListAction, nargs='?', type=int, choices=Chameleon.VALID_SETTINGS, help="retrieve or set the current setting")
     cmdArgGroup.add_argument("-U",  "--uid",         dest="uid",         action=CmdListAction, nargs='?',            help="retrieve or set the current UID")
     cmdArgGroup.add_argument("-c",  "--config",      dest="config",      action=CmdListAction, metavar="CFGNAME", nargs='?', help="retrieve or set the current configuration")
+    cmdArgGroup.add_argument("-lm",  "--logmode",    dest="logmode",     action=CmdListAction, metavar="LOGMODE", nargs='?', help="retrieve or set the current log mode")
     cmdArgGroup.add_argument("-lb",  "--lbutton",    dest="lbutton",     action=CmdListAction, metavar="ACTION", nargs='?', help="retrieve or set the current left button action")
     cmdArgGroup.add_argument("-rb",  "--rbutton",    dest="rbutton",     action=CmdListAction, metavar="ACTION", nargs='?', help="retrieve or set the current right button action")
     cmdArgGroup.add_argument("-gl",  "--gled",       dest="gled",        action=CmdListAction, metavar="FUNCTION", nargs='?', help="retrieve or set the current green led function")
@@ -192,6 +204,7 @@ def main():
                 "upload"    : cmdUpload,
                 "download"  : cmdDownload,
                 "log"       : cmdLog,
+                "logmode"   : cmdLogMode,
                 "lbutton"   : cmdLButton,
                 "rbutton"   : cmdRButton,
                 "gled"      : cmdGreenLED,

--- a/Software/chamtool.py
+++ b/Software/chamtool.py
@@ -143,8 +143,10 @@ def cmdThreshold(chameleon, arg):
             return "Setting threshold failed: {}".format(arg, result['statusText'])
 
 def cmdUpgrade(chameleon, arg):
-    result = chameleon.cmdUpgrade()
-    return ""
+    if(chameleon.cmdUpgrade() == 0):
+        print ("Device changed into Upgrade Mode")
+    exit(0)
+
 # Custom class for argparse
 class CmdListAction(argparse.Action):
     def __init__(self, option_strings, dest, default=False, required=False,

--- a/Software/requirements.txt
+++ b/Software/requirements.txt
@@ -1,1 +1,2 @@
 pyserial
+crcmod


### PR DESCRIPTION
Hi

I also did some upgrade of the chamlog tool, so that it can automatically check and remove parity bits from the sniffed PICC->PCD data, It also supports decoding the sniffed traces of Mifare DESFire.

Some new arguments are added to chamtool such as
-ug for upgrade
-lm for change settings for log mode
-th for setting threshold

Please feel free to test with PR:
Sniff Both Way 14443 #180 

@david-oswald @geo-rg 

Best