### PR TITLE
Global/Individual Settings for LED, Button, Log configurable by Terminal Command

### DIFF
--- a/Firmware/Chameleon-Mini/Button.c
+++ b/Firmware/Chameleon-Mini/Button.c
@@ -6,6 +6,7 @@
 #include "Map.h"
 #include "Terminal/CommandLine.h"
 #include "Application/Application.h"
+#include "UserInterface.h"
 
 #define BUTTON_PORT     	PORTA
 #define BUTTON_L			PIN5_bm
@@ -215,8 +216,17 @@ void ButtonTick(void)
         } else if (ButtonRPressTick == LONG_PRESS_TICK_COUNT) {
             /* Long button press detected execute button action and advance PressTickCounter
              * to an invalid state. */
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+			if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL){
+				ExecuteButtonAction(GLOBAL_UI_STORAGE.ButtonActions[BUTTON_R_PRESS_LONG]);
+			}
+			else {
+				ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_LONG]);
+			}
+#else
             ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_LONG]);
-            ButtonRPressTick++;
+#endif
+		    ButtonRPressTick++;
         } else {
             /* Button is still pressed, ignore */
         }
@@ -225,7 +235,16 @@ void ButtonTick(void)
          * a recent short button press. */
         if ( (ButtonRPressTick > 0) && (ButtonRPressTick <= LONG_PRESS_TICK_COUNT) ) {
             /* We have a short button press */
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+			if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL){
+				ExecuteButtonAction(GLOBAL_UI_STORAGE.ButtonActions[BUTTON_R_PRESS_SHORT]);
+			}
+			else {
+				ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_SHORT]);
+			}
+#else
             ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_SHORT]);
+#endif
         }
 
         ButtonRPressTick = 0;
@@ -239,8 +258,17 @@ void ButtonTick(void)
         } else if (ButtonLPressTick == LONG_PRESS_TICK_COUNT) {
             /* Long button press detected execute button action and advance PressTickCounter
              * to an invalid state. */
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+			if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL){
+				ExecuteButtonAction(GLOBAL_UI_STORAGE.ButtonActions[BUTTON_L_PRESS_LONG]);
+			}
+			else {
+				ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_LONG]);
+			}
+#else
             ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_LONG]);
-            ButtonLPressTick++;
+#endif     
+			ButtonLPressTick++;
         } else {
             /* Button is still pressed, ignore */
         }
@@ -249,7 +277,16 @@ void ButtonTick(void)
          * a recent short button press. */
         if ( (ButtonLPressTick > 0) && (ButtonLPressTick <= LONG_PRESS_TICK_COUNT) ) {
             /* We have a short button press */
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+			if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL){
+				ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_SHORT]);
+			}
+			else {
+				ExecuteButtonAction(GLOBAL_UI_STORAGE.ButtonActions[BUTTON_L_PRESS_SHORT]);
+			}
+#else
             ExecuteButtonAction(GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_SHORT]);
+#endif
         }
 
         ButtonLPressTick = 0;
@@ -263,6 +300,16 @@ void ButtonGetActionList(char* List, uint16_t BufferSize)
 
 void ButtonSetActionById(ButtonTypeEnum Type, ButtonActionEnum Action)
 {
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+	if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL){
+		GlobalSettings.ActiveSettingPtr->ButtonActions[Type] = Action;
+	}
+	else
+	{
+		GLOBAL_UI_STORAGE.ButtonActions[Type] = Action;
+	}
+#else
+	
 #ifndef BUTTON_SETTING_GLOBAL
     GlobalSettings.ActiveSettingPtr->ButtonActions[Type] = Action;
 #else
@@ -271,12 +318,24 @@ void ButtonSetActionById(ButtonTypeEnum Type, ButtonActionEnum Action)
         GlobalSettings.Settings[i].ButtonActions[Type] = Action;
     }
 #endif
+#endif
 }
 
 void ButtonGetActionByName(ButtonTypeEnum Type, char* Action, uint16_t BufferSize)
 {
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+	if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL){
+		 MapIdToText(ButtonActionMap, ARRAY_COUNT(ButtonActionMap),
+            GlobalSettings.ActiveSettingPtr->ButtonActions[Type], Action, BufferSize);
+	}
+	else {
+		 MapIdToText(ButtonActionMap, ARRAY_COUNT(ButtonActionMap),
+            GLOBAL_UI_STORAGE.ButtonActions[Type], Action, BufferSize);
+	}
+#else
     MapIdToText(ButtonActionMap, ARRAY_COUNT(ButtonActionMap),
             GlobalSettings.ActiveSettingPtr->ButtonActions[Type], Action, BufferSize);
+#endif
 }
 
 bool ButtonSetActionByName(ButtonTypeEnum Type, const char* Action)

--- a/Firmware/Chameleon-Mini/LED.c
+++ b/Firmware/Chameleon-Mini/LED.c
@@ -4,6 +4,7 @@
 
 #include "Terminal/CommandLine.h"
 #include "System.h"
+#include "UserInterface.h"
 
 #define BLINK_PRESCALER	1 /* x LEDTick(); */
 
@@ -109,6 +110,28 @@ void LEDGetFuncList(char* List, uint16_t BufferSize)
 
 void LEDSetFuncById(uint8_t Mask, LEDHookEnum Function)
 {
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+	if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL) {
+		if (Mask & LED_GREEN) {
+			GlobalSettings.ActiveSettingPtr->LEDGreenFunction = Function;
+		}
+
+		if (Mask & LED_RED) {
+			GlobalSettings.ActiveSettingPtr->LEDRedFunction = Function;
+		}
+	}
+	else
+	{
+        /* Always 1st setting is used */
+		if (Mask & LED_GREEN) {
+			GLOBAL_UI_STORAGE.LEDGreenFunction = Function;
+		}
+
+		if (Mask & LED_RED) {
+			GLOBAL_UI_STORAGE.LEDRedFunction = Function;
+		}
+	}
+#else
 #ifndef LED_SETTING_GLOBAL
     if (Mask & LED_GREEN) {
         GlobalSettings.ActiveSettingPtr->LEDGreenFunction = Function;
@@ -118,7 +141,7 @@ void LEDSetFuncById(uint8_t Mask, LEDHookEnum Function)
         GlobalSettings.ActiveSettingPtr->LEDRedFunction = Function;
     }
 #else
-    /* Write LED func to all settings when using global settings */
+	/* Write LED func to all settings when using global settings */
     for (uint8_t i=0; i<SETTINGS_COUNT; i++) {
         if (Mask & LED_GREEN) {
             GlobalSettings.Settings[i].LEDGreenFunction = Function;
@@ -128,6 +151,7 @@ void LEDSetFuncById(uint8_t Mask, LEDHookEnum Function)
             GlobalSettings.Settings[i].LEDRedFunction = Function;
         }
     }
+#endif
 #endif
 
     /* Clear modified LED and remove any pending actions */
@@ -145,13 +169,37 @@ void LEDSetFuncById(uint8_t Mask, LEDHookEnum Function)
 
 void LEDGetFuncByName(uint8_t Mask, char* Function, uint16_t BufferSize)
 {
-    if (Mask == LED_GREEN) {
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+	if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL) {
+		if (Mask == LED_GREEN) {
+        MapIdToText(LEDFunctionMap, ARRAY_COUNT(LEDFunctionMap),
+                GlobalSettings.ActiveSettingPtr->LEDGreenFunction, Function, BufferSize);
+		} else if (Mask == LED_RED) {
+			MapIdToText(LEDFunctionMap, ARRAY_COUNT(LEDFunctionMap),
+                GlobalSettings.ActiveSettingPtr->LEDRedFunction, Function, BufferSize);
+		
+		}
+	}
+	else
+	{
+		if (Mask == LED_GREEN) {
+        MapIdToText(LEDFunctionMap, ARRAY_COUNT(LEDFunctionMap),
+                GLOBAL_UI_STORAGE.LEDGreenFunction, Function, BufferSize);
+		} else if (Mask == LED_RED) {
+			MapIdToText(LEDFunctionMap, ARRAY_COUNT(LEDFunctionMap),
+                GLOBAL_UI_STORAGE.LEDRedFunction, Function, BufferSize);
+		
+		}
+	}
+ #else
+	if (Mask == LED_GREEN) {
         MapIdToText(LEDFunctionMap, ARRAY_COUNT(LEDFunctionMap),
                 GlobalSettings.ActiveSettingPtr->LEDGreenFunction, Function, BufferSize);
     } else if (Mask == LED_RED) {
         MapIdToText(LEDFunctionMap, ARRAY_COUNT(LEDFunctionMap),
                 GlobalSettings.ActiveSettingPtr->LEDRedFunction, Function, BufferSize);
     }
+#endif
 }
 
 bool LEDSetFuncByName(uint8_t Mask, const char* Function)

--- a/Firmware/Chameleon-Mini/LEDHook.h
+++ b/Firmware/Chameleon-Mini/LEDHook.h
@@ -13,7 +13,26 @@
 INLINE void LEDHook(LEDHookEnum Func, LEDActionEnum Action) {
     extern LEDActionEnum LEDGreenAction;
     extern LEDActionEnum LEDRedAction;
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL) {	
+	if (GlobalSettings.ActiveSettingPtr->LEDGreenFunction == Func) {
+			LEDGreenAction = Action;
+		}
 
+		if (GlobalSettings.ActiveSettingPtr->LEDRedFunction == Func) {
+			LEDRedAction = Action;
+		}
+	}
+	else {	
+		if (GLOBAL_UI_STORAGE.LEDGreenFunction == Func) {
+			LEDGreenAction = Action;
+		}
+
+		if (GLOBAL_UI_STORAGE.LEDRedFunction == Func) {
+			LEDRedAction = Action;
+		}
+	}
+#else
     if (GlobalSettings.ActiveSettingPtr->LEDGreenFunction == Func) {
         LEDGreenAction = Action;
     }
@@ -21,6 +40,7 @@ INLINE void LEDHook(LEDHookEnum Func, LEDActionEnum Action) {
     if (GlobalSettings.ActiveSettingPtr->LEDRedFunction == Func) {
         LEDRedAction = Action;
     }
+#endif
 }
 
 #endif /* LEDHOOK_H_ */

--- a/Firmware/Chameleon-Mini/Log.c
+++ b/Firmware/Chameleon-Mini/Log.c
@@ -4,6 +4,7 @@
 #include "System.h"
 #include "Map.h"
 #include "LEDHook.h"
+#include "UserInterface.h"
 
 static uint8_t LogMem[LOG_SIZE];
 static uint8_t *LogMemPtr;
@@ -63,8 +64,18 @@ static void LogFuncLive(LogEntryEnum Entry, const void* Data, uint8_t Length)
 
 void LogInit(void)
 {
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+	if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL) {
+		LogSetModeById(GlobalSettings.ActiveSettingPtr->LogMode);
+	}
+	else
+	{
+		LogSetModeById(GLOBAL_UI_STORAGE.LogMode);
+	}
+#else
     LogSetModeById(GlobalSettings.ActiveSettingPtr->LogMode);
-    LogMemPtr = LogMem;
+#endif
+	LogMemPtr = LogMem;
     LogMemLeft = sizeof(LogMem);
 
     uint8_t result;
@@ -166,6 +177,16 @@ uint16_t LogMemFree(void)
 
 void LogSetModeById(LogModeEnum Mode)
 {
+	
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+	if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL) {
+		GlobalSettings.ActiveSettingPtr->LogMode = Mode;
+	}
+	else
+	{
+		GLOBAL_UI_STORAGE.LogMode = Mode;
+	}
+#else
 #ifndef LOG_SETTING_GLOBAL
     GlobalSettings.ActiveSettingPtr->LogMode = Mode;
 #else
@@ -174,7 +195,7 @@ void LogSetModeById(LogModeEnum Mode)
          GlobalSettings.Settings[i].LogMode = Mode;
     }
 #endif
-
+#endif
     switch(Mode) {
     case LOG_MODE_OFF:
         EnableLogSRAMtoFRAM = false;
@@ -211,8 +232,20 @@ bool LogSetModeByName(const char* Mode)
 
 void LogGetModeByName(char* Mode, uint16_t BufferSize)
 {
-    MapIdToText(LogModeMap, ARRAY_COUNT(LogModeMap),
+	
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+	if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL) {
+		MapIdToText(LogModeMap, ARRAY_COUNT(LogModeMap),
+		GlobalSettings.ActiveSettingPtr->LogMode, Mode, BufferSize);
+	}
+	else {
+		MapIdToText(LogModeMap, ARRAY_COUNT(LogModeMap),
+		GLOBAL_UI_STORAGE.LogMode, Mode, BufferSize);
+	}
+#else
+	MapIdToText(LogModeMap, ARRAY_COUNT(LogModeMap),
             GlobalSettings.ActiveSettingPtr->LogMode, Mode, BufferSize);
+#endif
 }
 
 void LogGetModeList(char* List, uint16_t BufferSize)

--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -39,15 +39,17 @@ SETTINGS	+= -DDEFAULT_RBUTTON_ACTION=BUTTON_ACTION_CYCLE_SETTINGS
 #SETTINGS	+= -DDEFAULT_RBUTTON_ACTION=BUTTON_ACTION_STORE_MEM
 SETTINGS	+= -DDEFAULT_LBUTTON_ACTION=BUTTON_ACTION_RECALL_MEM
 
+SETTINGS    += -DUSER_INTERFACE_MODE_CONFIGURABLE
+
 #Define if button action setting should be independent of active setting 
-SETTINGS	+= -DBUTTON_SETTING_GLOBAL
+#SETTINGS	+= -DBUTTON_SETTING_GLOBAL
 
 #Default LED functions
 SETTINGS	+= -DDEFAULT_RED_LED_ACTION=LED_SETTING_CHANGE
 SETTINGS	+= -DDEFAULT_GREEN_LED_ACTION=LED_POWERED
 
 #Define if LED function setting should be independent of active setting
-SETTINGS	+= -DLED_SETTING_GLOBAL
+#SETTINGS	+= -DLED_SETTING_GLOBAL
 
 #Default logging mode
 SETTINGS	+= -DDEFAULT_LOG_MODE=LOG_MODE_OFF
@@ -55,7 +57,7 @@ SETTINGS	+= -DDEFAULT_LOG_MODE=LOG_MODE_OFF
 #SETTINGS	+= -DDEFAULT_LOG_MODE=LOG_MODE_TERMINAL
 
 #Define if log settings should be global
-SETTINGS	+= -DLOG_SETTING_GLOBAL
+#SETTINGS	+= -DLOG_SETTING_GLOBAL
 
 #Default setting
 SETTINGS	+= -DDEFAULT_SETTING=SETTINGS_FIRST
@@ -68,6 +70,9 @@ SETTINGS	+= -DDEFAULT_READER_THRESHOLD=400
 
 #Use EEPROM to store settings
 SETTINGS	+= -DENABLE_EEPROM_SETTINGS
+
+#Default user interface mode
+SETTINGS	+= -DDEFAULT_USERINTERFACE_MODE=USER_INTERFACE_GLOBAL
 
 #Memory definitions and objcopy flags to include sections in binaries
 FLASH_DATA_ADDR = 0x10000 #Start of data section in flash
@@ -94,6 +99,7 @@ SRC         += $(TARGET).c LUFADescriptors.c System.c Configuration.c Random.c C
 SRC         += Terminal/Terminal.c Terminal/Commands.c Terminal/XModem.c Terminal/CommandLine.c
 SRC         += Codec/Codec.c Codec/ISO14443-2A.c Codec/Reader14443-2A.c Codec/SniffISO14443-2A.c Codec/Reader14443-ISR.S
 SRC         += Application/MifareUltralight.c Application/MifareClassic.c Application/ISO14443-3A.c Application/Crypto1.c Application/Reader14443A.c Application/Sniff14443A.c
+SRC			+= UserInterface.c
 SRC         += $(LUFA_SRC_USB) $(LUFA_SRC_USBCLASS)
 LUFA_PATH    = ../LUFA
 CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR) -DFLASH_DATA_SIZE=$(FLASH_DATA_SIZE) -DSPM_HELPER_ADDR=$(SPM_HELPER_ADDR) -DBUILD_DATE=$(BUILD_DATE) -DCOMMIT_ID=\"$(COMMIT_ID)\" $(SETTINGS)

--- a/Firmware/Chameleon-Mini/Settings.c
+++ b/Firmware/Chameleon-Mini/Settings.c
@@ -26,8 +26,9 @@ SettingsType EEMEM StoredSettings = {
         .LEDRedFunction = DEFAULT_RED_LED_ACTION,
         .LEDGreenFunction = DEFAULT_GREEN_LED_ACTION,
         .PendingTaskTimeout = DEFAULT_PENDING_TASK_TIMEOUT,
-        .ReaderThreshold = DEFAULT_READER_THRESHOLD
-    }}
+        .ReaderThreshold = DEFAULT_READER_THRESHOLD,
+    }},
+	.UserInterfaceMode = DEFAULT_USERINTERFACE_MODE
 };
 
 void SettingsLoad(void) {
@@ -74,7 +75,36 @@ bool SettingsSetActiveById(uint8_t Setting) {
 
             /* Settings have changed. Progress changes through system */
             ConfigurationSetById(GlobalSettings.ActiveSettingPtr->Configuration);
-            LogSetModeById(GlobalSettings.ActiveSettingPtr->LogMode);
+
+			
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+			if ( GlobalSettings.UserInterfaceMode == USER_INTERFACE_INDIVIDUAL) {
+				LogSetModeById(GlobalSettings.ActiveSettingPtr->LogMode);
+				LEDSetFuncById(LED_RED,GlobalSettings.ActiveSettingPtr->LEDRedFunction);
+				LEDSetFuncById(LED_GREEN,GlobalSettings.ActiveSettingPtr->LEDGreenFunction);
+				ButtonSetActionById(BUTTON_L_PRESS_SHORT,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_SHORT]);
+				ButtonSetActionById(BUTTON_R_PRESS_SHORT,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_SHORT]);
+				ButtonSetActionById(BUTTON_L_PRESS_LONG,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_LONG]);
+				ButtonSetActionById(BUTTON_R_PRESS_LONG,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_LONG]);
+			}
+			else {
+				LogSetModeById(GlobalSettings.Settings[0].LogMode);
+				LEDSetFuncById(LED_RED,GlobalSettings.Settings[0].LEDRedFunction);
+				LEDSetFuncById(LED_GREEN,GlobalSettings.Settings[0].LEDGreenFunction);
+				ButtonSetActionById(BUTTON_L_PRESS_SHORT,GlobalSettings.Settings[0].ButtonActions[BUTTON_L_PRESS_SHORT]);
+				ButtonSetActionById(BUTTON_R_PRESS_SHORT,GlobalSettings.Settings[0].ButtonActions[BUTTON_R_PRESS_SHORT]);
+				ButtonSetActionById(BUTTON_L_PRESS_LONG,GlobalSettings.Settings[0].ButtonActions[BUTTON_L_PRESS_LONG]);
+				ButtonSetActionById(BUTTON_R_PRESS_LONG,GlobalSettings.Settings[0].ButtonActions[BUTTON_R_PRESS_LONG]);
+			}
+#else
+	        LogSetModeById(GlobalSettings.ActiveSettingPtr->LogMode);
+			LEDSetFuncById(LED_RED,GlobalSettings.ActiveSettingPtr->LEDRedFunction);
+			LEDSetFuncById(LED_GREEN,GlobalSettings.ActiveSettingPtr->LEDGreenFunction);
+			ButtonSetActionById(BUTTON_L_PRESS_SHORT,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_SHORT]);
+			ButtonSetActionById(BUTTON_R_PRESS_SHORT,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_SHORT]);
+			ButtonSetActionById(BUTTON_L_PRESS_LONG,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_L_PRESS_LONG]);
+			ButtonSetActionById(BUTTON_R_PRESS_LONG,GlobalSettings.ActiveSettingPtr->ButtonActions[BUTTON_R_PRESS_LONG]);
+#endif
 
             /* Recall new memory contents */
             MemoryRecall();

--- a/Firmware/Chameleon-Mini/Settings.h
+++ b/Firmware/Chameleon-Mini/Settings.h
@@ -13,6 +13,7 @@
 #include "Log.h"
 #include "LED.h"
 #include "Memory.h"
+#include "UserInterface.h"
 #include <avr/eeprom.h>
 
 #define SETTINGS_COUNT		(MEMORY_SIZE / MEMORY_SIZE_PER_SETTING)
@@ -37,6 +38,7 @@ typedef struct {
     uint8_t ActiveSettingIdx;
     SettingsEntryType* ActiveSettingPtr;
     SettingsEntryType Settings[SETTINGS_COUNT];
+	UserInterfaceModeEnum UserInterfaceMode; // UserInterface Mode (Global/Individual)
 } SettingsType;
 
 extern SettingsType GlobalSettings, StoredSettings;
@@ -61,6 +63,8 @@ INLINE void SettingUpdate(const void * addr, uint16_t size)
 
 #endif
 }
+
+#define GLOBAL_UI_STORAGE GlobalSettings.Settings[0]
 
 #define SETTING_UPDATE(x)	SettingUpdate(&(x), sizeof(x))
 

--- a/Firmware/Chameleon-Mini/Terminal/CommandLine.c
+++ b/Firmware/Chameleon-Mini/Terminal/CommandLine.c
@@ -316,6 +316,15 @@ const PROGMEM CommandEntryType CommandTable[] = {
     .SetFunc        = NO_FUNCTION,
     .GetFunc        = NO_FUNCTION
   },
+  #ifdef USER_INTERFACE_MODE_CONFIGURABLE
+  {
+    .Command        = COMMAND_USERINTERFACE,
+    .ExecFunc       = NO_FUNCTION,
+    .ExecParamFunc  = NO_FUNCTION,
+    .SetFunc        = CommandSetUserInterface,
+    .GetFunc        = CommandGetUserInterface
+  },
+  #endif
   { /* This has to be last element */
     .Command    = COMMAND_LIST_END,
     .ExecFunc   = NO_FUNCTION,

--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -667,3 +667,24 @@ CommandStatusIdType CommandExecClone(char *OutMessage)
 
     return TIMEOUT_COMMAND;
 }
+
+CommandStatusIdType CommandSetUserInterface(char* OutMessage, const char* InParam)
+{
+    if (COMMAND_IS_SUGGEST_STRING(InParam)) {
+        UserInterfaceModeList(OutMessage, TERMINAL_BUFFER_SIZE);
+        return COMMAND_INFO_OK_WITH_TEXT_ID;
+    } else if (UserInterfaceSetModeByName(InParam)) {
+        SettingsSave();
+        return COMMAND_INFO_OK_ID;
+    } else {
+        return COMMAND_ERR_INVALID_PARAM_ID;
+    }
+}
+
+
+CommandStatusIdType CommandGetUserInterface(char* OutParam)
+{
+    UserInterfaceGetModeByName(OutParam, TERMINAL_BUFFER_SIZE);
+    return COMMAND_INFO_OK_WITH_TEXT_ID;
+}
+

--- a/Firmware/Chameleon-Mini/Terminal/Commands.h
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.h
@@ -187,6 +187,11 @@ CommandStatusIdType CommandGetField(char* OutMessage);
 #define COMMAND_CLONE  "CLONE"
 CommandStatusIdType CommandExecClone(char* OutMessage);
 
+#ifdef	USER_INTERFACE_MODE_CONFIGURABLE
+#define COMMAND_USERINTERFACE "USER_INTERFACE"
+CommandStatusIdType CommandSetUserInterface(char* OutMessage, const char* InParam);
+CommandStatusIdType CommandGetUserInterface(char* OutMessage);
+#endif
 #define COMMAND_LIST_END    ""
 /* Defines the end of command list. This is no actual command */
 

--- a/Firmware/Chameleon-Mini/UserInterface.c
+++ b/Firmware/Chameleon-Mini/UserInterface.c
@@ -1,0 +1,52 @@
+#include "UserInterface.h"
+#include "Random.h"
+#include "Common.h"
+#include "Settings.h"
+#include "Memory.h"
+#include "Map.h"
+#include "Terminal/CommandLine.h"
+#include "Application/Application.h"
+
+
+
+static const MapEntryType PROGMEM UserInterfaceModeMap[] = {
+    { .Id = USER_INTERFACE_GLOBAL,					.Text = "GLOBAL" },
+    { .Id = USER_INTERFACE_INDIVIDUAL,			.Text = "INDIVIDUAL" },
+};
+
+void UserInterfaceModeInit(void)
+{
+    ConfigurationSetById(GlobalSettings.UserInterfaceMode);
+}
+
+void UserInferfaceModeSetById( UserInterfaceModeEnum Mode )
+{
+     CommandLinePendingTaskBreak(); // break possibly pending task
+
+    GlobalSettings.UserInterfaceMode = Mode;
+
+}
+
+void UserInterfaceGetModeByName(char* Mode, uint16_t BufferSize)
+{
+    MapIdToText(UserInterfaceModeMap, ARRAY_COUNT(UserInterfaceModeMap), GlobalSettings.UserInterfaceMode, Mode, BufferSize);
+}
+
+bool UserInterfaceSetModeByName(const char* Mode)
+{
+    MapIdType Id;
+
+    if (MapTextToId(UserInterfaceModeMap, ARRAY_COUNT(UserInterfaceModeMap), Mode, &Id)) {
+        UserInferfaceModeSetById(Id);
+        LogEntry(LOG_INFO_CONFIG_SET, Mode, StringLength(Mode, CONFIGURATION_NAME_LENGTH_MAX-1));
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void UserInterfaceModeList(char* List, uint16_t BufferSize)
+{
+    MapToString(UserInterfaceModeMap, ARRAY_COUNT(UserInterfaceModeMap), List, BufferSize);
+}
+

--- a/Firmware/Chameleon-Mini/UserInterface.h
+++ b/Firmware/Chameleon-Mini/UserInterface.h
@@ -1,0 +1,26 @@
+/*
+ * UserInterface.h
+ *
+ *  Created on: 30.11.2018
+ *      Author: vrumfondel
+ */
+
+#ifndef USERINTERFACE_H_
+#define USERINTERFACE_H_
+
+#include "Common.h"
+
+typedef enum {
+    USER_INTERFACE_GLOBAL = 0,
+    USER_INTERFACE_INDIVIDUAL,
+    /* Must be last element */
+    USER_INTERFACE_COUNT
+} UserInterfaceModeEnum;
+
+void UserInterfaceModeList(char* List, uint16_t BufferSize);
+void UserInterfaceModeById(UserInterfaceModeEnum Mode);
+void UserInterfaceGetModeByName(char* Mode, uint16_t BufferSize);
+bool UserInterfaceSetModeByName(const char* Mode);
+
+
+#endif /* USERINTERFACE_H_ */


### PR DESCRIPTION
Adding functionality to select Global or Individual Settings for LED, Button, Log by terminal command

To use, enable "SETTINGS    += -DUSER_INTERFACE_MODE_CONFIGURABLE" in Makefile. This overrides "SETTINGS	+= -DBUTTON_SETTING_GLOBAL" and others.
New command: "USER_INTERFACE", Parameters "GLOBAL", "INDIVIDUAL".
When in global mode, settings are stored at location GLOBAL_UI_STORAGE defined in Settings.h. Currently it is set to use GlobalSettings.Settings[0] (Setting for Config 1).
