### PR TITLE
make style proposition

### DIFF
--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -173,3 +173,18 @@ dfu-prog: $(TARGET).hex $(TARGET).eep
 	dfu-programmer $(MCU) flash-eeprom $(TARGET).eep
 	dfu-programmer $(MCU) flash $(TARGET).hex
 	dfu-programmer $(MCU) reset
+
+style:
+	# Make sure astyle is installed
+	@which astyle >/dev/null || ( echo "Please install 'astyle' package first" ; exit 1 )
+	# Remove spaces & tabs at EOL, add LF at EOF if needed on *.c, *.h, Makefile
+	find . \( -name "*.[ch]" -or -name "Makefile" \) \
+	    -exec perl -pi -e 's/[ \t]+$$//' {} \; \
+	    -exec sh -c "tail -c1 {} | xxd -p | tail -1 | grep -q -v 0a$$" \; \
+	    -exec sh -c "echo >> {}" \;
+	# Apply astyle on *.c, *.h
+	find . -name "*.[ch]" -exec astyle --formatted --mode=c --suffix=none \
+	    --indent=spaces=4 --indent-switches \
+	    --keep-one-line-blocks --max-instatement-indent=60 \
+	    --style=google --pad-oper --unpad-paren --pad-header \
+	    --align-pointer=name {} \;


### PR DESCRIPTION
Hi,

I observed that the coding style varies quite a lot across the code.
E.g.:
* bracket after function declaration sometimes with a newline, sometimes not
* bracket after if declaration sometimes with a newline, sometimes not
* tabulations here & there
* spaces around parenthesis and between args follow non-uniform patterns
* indentation sometimes is wrong
* etc

What we used since years in the libnfc and since several months in the proxmark3 RRG repo is a few script rules to enforce one common style across the whole code.
Usage is to run "make style" from time to time to reformat the newly submitted code.

Here is one proposition, using the same style as in proxmark3 and as used in some parts of the chameleonmini code.
Of course this can be discussed and tuned to other tastes but I think it's very helpful that once one choice is frozen, the style is applied consistently across the code.
See http://astyle.sourceforge.net/astyle.html for other tunings.
Beware that when used the very first time, this will introduce a lot of changes in the code so it has to be done in a separate commit.

What do you think?
By experience it has been very helpful for both libnfc & proxmark3 RRG projects.
