### PR TITLE
CLONE_MFU: command and button action

### DIFF
--- a/Firmware/Chameleon-Mini/Application/Reader14443A.h
+++ b/Firmware/Chameleon-Mini/Application/Reader14443A.h
@@ -30,7 +30,8 @@ typedef enum {
     Reader14443_Autocalibrate,
     Reader14443_Read_MF_Ultralight,
     Reader14443_Identify,
-    Reader14443_Identify_Clone
+    Reader14443_Identify_Clone,
+    Reader14443_Clone_MF_Ultralight
 } Reader14443Command;
 
 

--- a/Firmware/Chameleon-Mini/Button.c
+++ b/Firmware/Chameleon-Mini/Button.c
@@ -30,6 +30,7 @@ static const MapEntryType PROGMEM ButtonActionMap[] = {
     { .Id = BUTTON_ACTION_TOGGLE_FIELD,			.Text = "TOGGLE_FIELD" },
     { .Id = BUTTON_ACTION_STORE_LOG,			.Text = "STORE_LOG" },
     { .Id = BUTTON_ACTION_CLONE,			.Text = "CLONE" },
+    { .Id = BUTTON_ACTION_CLONE_MFU,			.Text = "CLONE_MFU" },
 };
 
 static void ExecuteButtonAction(ButtonActionEnum ButtonAction) {
@@ -177,6 +178,10 @@ static void ExecuteButtonAction(ButtonActionEnum ButtonAction) {
         case BUTTON_ACTION_CLONE: {
             CommandExecute("CLONE");
             break;
+        }
+        case BUTTON_ACTION_CLONE_MFU: {
+          CommandExecute("CLONE_MFU");
+          break;
         }
 
         default:

--- a/Firmware/Chameleon-Mini/Button.h
+++ b/Firmware/Chameleon-Mini/Button.h
@@ -33,6 +33,7 @@ typedef enum {
     BUTTON_ACTION_TOGGLE_FIELD,
     BUTTON_ACTION_STORE_LOG,
     BUTTON_ACTION_CLONE,
+    BUTTON_ACTION_CLONE_MFU,
 
     /* This has to be last element */
     BUTTON_ACTION_COUNT

--- a/Firmware/Chameleon-Mini/Terminal/CommandLine.c
+++ b/Firmware/Chameleon-Mini/Terminal/CommandLine.c
@@ -275,6 +275,13 @@ const PROGMEM CommandEntryType CommandTable[] = {
         .GetFunc 	= NO_FUNCTION
     },
     {
+        .Command	= COMMAND_CLONE_MFU,
+        .ExecFunc 	= CommandExecCloneMFU,
+        .ExecParamFunc  = NO_FUNCTION,
+        .SetFunc 	= NO_FUNCTION,
+        .GetFunc 	= NO_FUNCTION
+    },
+    {
         .Command	= COMMAND_IDENTIFY_CARD,
         .ExecFunc 	= CommandExecIdentifyCard,
         .ExecParamFunc = NO_FUNCTION,

--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -488,6 +488,17 @@ CommandStatusIdType CommandExecDumpMFU(char *OutMessage) {
     return TIMEOUT_COMMAND;
 }
 
+CommandStatusIdType CommandExecCloneMFU(char *OutMessage) {
+    ConfigurationSetById(CONFIG_ISO14443A_READER);
+    ApplicationReset();
+
+    Reader14443CurrentCommand = Reader14443_Clone_MF_Ultralight;
+    Reader14443AAppInit();
+    Reader14443ACodecStart();
+    CommandLinePendingTaskTimeout = &Reader14443AAppTimeout;
+    return TIMEOUT_COMMAND;
+}
+
 CommandStatusIdType CommandExecGetUid(char *OutMessage) { // this function is for reading the uid in reader mode
     if (GlobalSettings.ActiveSettingPtr->Configuration != CONFIG_ISO14443A_READER)
         return COMMAND_ERR_INVALID_USAGE_ID;

--- a/Firmware/Chameleon-Mini/Terminal/Commands.h
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.h
@@ -166,6 +166,9 @@ CommandStatusIdType CommandExecGetUid(char *OutMessage);
 #define COMMAND_DUMP_MFU	"DUMP_MFU"
 CommandStatusIdType CommandExecDumpMFU(char *OutMessage);
 
+#define COMMAND_CLONE_MFU	"CLONE_MFU"
+CommandStatusIdType CommandExecCloneMFU(char *OutMessage);
+
 #define COMMAND_IDENTIFY_CARD	"IDENTIFY"
 CommandStatusIdType CommandExecIdentifyCard(char *OutMessage);
 


### PR DESCRIPTION
This adds automatic cloning of Mifare Ultralight cards to the selected
setting.

Currently, only the DUMP_MFU command existed. In order to clone a Mifare
Ultralight card, the user had to convert the hex output of DUMP_MFU to binary
and upload the result to the card.

The CLONE_MFU command will attempt to read and store the Mifare Ultralight
contents directy to the slot which is then transitioned to emulation mode.

The CLONE_MFU button action does the same, so the board can be configured to
clone cards by simply selecting a slot with one button and cloning with the
other.