### PR TITLE
Updated code to build with GCC 10 - Updated ISR Sharing

### DIFF
--- a/Firmware/Chameleon-Mini/Application/EM4233.c
+++ b/Firmware/Chameleon-Mini/Application/EM4233.c
@@ -23,9 +23,6 @@ static enum {
 } State;
 
 bool loggedIn;
-uint8_t MyAFI; /* This variable holds current tag's AFI (is used in inventory) */
-
-CurrentFrame FrameInfo;
 
 void EM4233AppInit(void) {
     State = STATE_READY;

--- a/Firmware/Chameleon-Mini/Application/ISO15693-A.c
+++ b/Firmware/Chameleon-Mini/Application/ISO15693-A.c
@@ -2,6 +2,9 @@
 #include "../Common.h"
 #include <util/crc16.h>
 
+CurrentFrame FrameInfo;
+uint8_t MyAFI;
+
 //Refer to ISO/IEC 15693-3:2001 page 41
 uint16_t calculateCRC(void *FrameBuf, uint16_t FrameBufSize) {
     uint16_t reg = ISO15693_CRC16_PRESET;

--- a/Firmware/Chameleon-Mini/Application/ISO15693-A.h
+++ b/Firmware/Chameleon-Mini/Application/ISO15693-A.h
@@ -85,6 +85,8 @@ typedef struct {
     bool Addressed;
     bool Selected;
 } CurrentFrame;
+extern CurrentFrame FrameInfo;  /* Holds current frame information */
+extern uint8_t MyAFI;           /* Holds current tag's AFI (is used in inventory) */
 
 void ISO15693AppendCRC(uint8_t *FrameBuf, uint16_t FrameBufSize);
 bool ISO15693CheckCRC(void *FrameBuf, uint16_t FrameBufSize);

--- a/Firmware/Chameleon-Mini/Application/Reader14443A.c
+++ b/Firmware/Chameleon-Mini/Application/Reader14443A.c
@@ -19,6 +19,9 @@
 
 // TODO replace remaining magic numbers
 
+uint8_t ReaderSendBuffer[CODEC_BUFFER_SIZE];
+uint16_t ReaderSendBitCount;
+
 static bool Selected = false;
 Reader14443Command Reader14443CurrentCommand = Reader14443_Do_Nothing;
 

--- a/Firmware/Chameleon-Mini/Application/Reader14443A.h
+++ b/Firmware/Chameleon-Mini/Application/Reader14443A.h
@@ -6,8 +6,8 @@
 
 #define CRC_INIT 0x6363
 
-uint8_t ReaderSendBuffer[CODEC_BUFFER_SIZE];
-uint16_t ReaderSendBitCount;
+extern uint8_t ReaderSendBuffer[];
+extern uint16_t ReaderSendBitCount;
 
 void Reader14443AAppInit(void);
 void Reader14443AAppReset(void);

--- a/Firmware/Chameleon-Mini/Application/TITagitstandard.c
+++ b/Firmware/Chameleon-Mini/Application/TITagitstandard.c
@@ -16,10 +16,8 @@ static enum {
     STATE_QUIET
 } State;
 
-uint8_t MyAFI;                      /* Holds current tag's AFI (is used in inventory) */
 uint16_t UserLockBits_Mask = 0;     /* Holds lock state of blocks */
 uint16_t FactoryLockBits_Mask = 0;  /* Holds lock state of blocks */
-CurrentFrame FrameInfo;
 
 void TITagitstandardAppInit(void) {
     State = STATE_READY;

--- a/Firmware/Chameleon-Mini/Codec/Codec.c
+++ b/Firmware/Chameleon-Mini/Codec/Codec.c
@@ -24,6 +24,11 @@ static volatile struct {
 
 uint8_t CodecBuffer[CODEC_BUFFER_SIZE];
 uint8_t CodecBuffer2[CODEC_BUFFER_SIZE];
+
+void (* volatile isr_func_CODEC_TIMER_LOADMOD_CCB_VECT)(void) = NULL;
+void (* volatile isr_func_TCD0_CCC_vect)(void) = NULL;
+void (* volatile isr_func_CODEC_DEMOD_IN_INT0_VECT)(void) = NULL;
+
 // the following three functions prevent sending data directly after turning on the reader field
 void CodecReaderFieldStart(void) { // DO NOT CALL THIS FUNCTION INSIDE APPLICATION!
     if (!CodecGetReaderField() && !ReaderFieldFlags.ToBeRestarted) {

--- a/Firmware/Chameleon-Mini/Codec/Codec.h
+++ b/Firmware/Chameleon-Mini/Codec/Codec.h
@@ -116,13 +116,14 @@ typedef enum {
 extern uint8_t CodecBuffer[CODEC_BUFFER_SIZE];
 extern uint8_t CodecBuffer2[CODEC_BUFFER_SIZE];
 
-void (* volatile isr_func_TCD0_CCC_vect)(void);
+/* Shared ISR pointers and handlers */
+extern void (* volatile isr_func_TCD0_CCC_vect)(void);
 void isr_Reader14443_2A_TCD0_CCC_vect(void);
 void isr_ISO15693_CODEC_TIMER_SAMPLING_CCC_VECT(void);
-void (* volatile isr_func_CODEC_DEMOD_IN_INT0_VECT)(void);
+extern void (* volatile isr_func_CODEC_DEMOD_IN_INT0_VECT)(void);
 void isr_ISO14443_2A_TCD0_CCC_vect(void);
 void isr_ISO15693_CODEC_DEMOD_IN_INT0_VECT(void);
-void (* volatile isr_func_CODEC_TIMER_LOADMOD_CCB_VECT)(void);
+extern void (* volatile isr_func_CODEC_TIMER_LOADMOD_CCB_VECT)(void);
 void isr_ISO15693_CODEC_TIMER_LOADMOD_CCB_VECT(void);
 void isr_SniffISO14443_2A_CODEC_TIMER_LOADMOD_CCB_VECT(void);
 

--- a/Firmware/Chameleon-Mini/Codec/ISO15693.c
+++ b/Firmware/Chameleon-Mini/Codec/ISO15693.c
@@ -88,7 +88,6 @@ static volatile uint16_t ReadCommandFromReader = 0;
  * CODEC_DEMOD_IN_PORT.INT0MASK = CODEC_DEMOD_IN_MASK0;
  * and unregistered writing the INT0MASK to 0
  */
-// ISR(CODEC_DEMOD_IN_INT0_VECT)
 ISR_SHARED isr_ISO15693_CODEC_DEMOD_IN_INT0_VECT(void) {
     /* Start sample timer CODEC_TIMER_SAMPLING (TCD0).
      * Set Counter Channel C (CCC) with relevant bitmask (TC0_CCCIF_bm),
@@ -258,7 +257,7 @@ ISR_SHARED isr_ISO15693_CODEC_TIMER_SAMPLING_CCC_VECT(void) {
  * It disables its own interrupt when all data has been sent
  */
 //ISR(CODEC_TIMER_LOADMOD_CCB_VECT)
-void isr_ISO15693_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
+ISR_SHARED isr_ISO15693_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
     static void *JumpTable[] = {
         [LOADMOD_START_SINGLE]  = && LOADMOD_START_SINGLE_LABEL,
         [LOADMOD_SOF_SINGLE]    = && LOADMOD_SOF_SINGLE_LABEL,

--- a/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.c
+++ b/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.c
@@ -56,6 +56,8 @@ static volatile uint16_t ReaderBitCount;
 static volatile uint16_t CardBitCount;
 static volatile uint16_t rawBitCount;
 
+enum RCTraffic TrafficSource;
+
 INLINE void CardSniffInit(void);
 INLINE void CardSniffDeinit(void);
 
@@ -351,16 +353,13 @@ ISR(ACA_AC0_vect) { // this interrupt either finds the SOC or gets triggered bef
     StateRegister = PICC_FRAME;
 }
 
-ISR(CODEC_TIMER_LOADMOD_CCB_VECT) { // pause found
-    isr_func_CODEC_TIMER_LOADMOD_CCB_VECT();
-}
-
+// Called once a pause is found
 // Decode the Card -> Reader signal
 // according to the pause and modulated period
 // if the half bit duration is modulated, then add 1 to buffer
 // if the half bit duration is not modulated, then add 0 to buffer
 //ISR(CODEC_TIMER_LOADMOD_CCB_VECT) // pause found
-void isr_SniffISO14443_2A_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
+ISR_SHARED isr_SniffISO14443_2A_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
     uint8_t tmp = CODEC_TIMER_TIMESTAMPS.CNTL;
     CODEC_TIMER_TIMESTAMPS.CNT = 0;
 

--- a/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.h
+++ b/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.h
@@ -9,7 +9,7 @@
 #include "Codec.h"
 #include "Terminal/CommandLine.h"
 
-enum RCTraffic {TRAFFIC_READER, TRAFFIC_CARD} TrafficSource;
+extern enum RCTraffic {TRAFFIC_READER, TRAFFIC_CARD} TrafficSource;
 /* Codec Interface */
 void Sniff14443ACodecInit(void);
 void Sniff14443ACodecDeInit(void);

--- a/Firmware/Chameleon-Mini/ISRSharing.S
+++ b/Firmware/Chameleon-Mini/ISRSharing.S
@@ -9,7 +9,7 @@
 #include "Codec/Codec.h"
 #include <avr/interrupt.h>
 
-; Use this macro to call isr functions
+; Macro to call ISR functions
 .macro call_isr isr_address
 push r30
 push r31
@@ -21,12 +21,28 @@ pop r30
 reti
 .endm
 
-; Find first pause and start sampling
+; Shared ISR must be defined below as globals
+; Example:
+;
+; .global <INTERRUPT-TO-SHARE>
+; INTERRUPT-TO-SHARE:
+;     call_isr POINTER-TO-VARIABLE-INTERRUPT-HANDLER
+;
+; Where:
+; INTERRUPT-TO-SHARE
+;   The target interrupt which needs to be shared
+; POINTER-TO-VARIABLE-INTERRUPT-HANDLER
+;   A pointer to the interrupt handler which can be modified at runtime.
+;   Must be a volatile pointer to function declared in Codec.h
+
 .global CODEC_DEMOD_IN_INT0_VECT
 CODEC_DEMOD_IN_INT0_VECT:
     call_isr isr_func_CODEC_DEMOD_IN_INT0_VECT
 
-; Frame Delay Time PCD to PICC ends
 .global CODEC_TIMER_SAMPLING_CCC_VECT
 CODEC_TIMER_SAMPLING_CCC_VECT:
     call_isr isr_func_TCD0_CCC_vect
+
+.global CODEC_TIMER_LOADMOD_CCB_VECT
+CODEC_TIMER_LOADMOD_CCB_VECT:
+    call_isr isr_func_CODEC_TIMER_LOADMOD_CCB_VECT

--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -15,6 +15,7 @@
 #include "../AntennaLevel.h"
 #include "../Battery.h"
 #include "../Codec/Codec.h"
+#include "../Application/Reader14443A.h"
 
 extern Reader14443Command Reader14443CurrentCommand;
 extern Sniff14443Command Sniff14443CurrentCommand;


### PR DESCRIPTION
Since GCC 10, the compiler defaults to `-fno-common` ([changelog](https://gcc.gnu.org/gcc-10/changes.html#c)), thus variables with multiple tentative definitions result in linker errors.
We've (me and @MrMoDDoM) extern-ed the shared variables to fix the issue.
I've tested the Chameleon with different configs (iso14/iso15) and it seems to be working. Further testing might be needed, but I'm confident the changes _shouldn't break anything_ ™

Also, when I implemented ISR sharing, somehow I forgot about a function which had to be shared as well, so I fixed that mistake and added a couple of comments on how shared function calls work.