### PR TITLE
ISO15693 codec and applications updates

### DIFF
--- a/Firmware/Chameleon-Mini/Application/EM4233.c
+++ b/Firmware/Chameleon-Mini/Application/EM4233.c
@@ -23,9 +23,6 @@ static enum {
 } State;
 
 bool loggedIn;
-uint8_t MyAFI; /* This variable holds current tag's AFI (is used in inventory) */
-
-CurrentFrame FrameInfo;
 
 void EM4233AppInit(void) {
     State = STATE_READY;

--- a/Firmware/Chameleon-Mini/Application/EM4233.c
+++ b/Firmware/Chameleon-Mini/Application/EM4233.c
@@ -137,7 +137,7 @@ uint16_t EM4233_Read_Single(uint8_t *FrameBuf, uint16_t FrameBytes) {
     if (BlockAddress >= EM4233_NUMBER_OF_BLCKS) { /* check if the reader is requesting a sector out of bound */
         if (FrameInfo.Addressed) { /* If the request is addressed */
             FrameBuf[ISO15693_ADDR_FLAGS] = ISO15693_RES_FLAG_ERROR;
-            FrameBuf[ISO15693_RES_ADDR_PARAM] = 0x0F; /* Magic number from real tag */
+            FrameBuf[ISO15693_RES_ADDR_PARAM] = ISO15693_RES_ERR_GENERIC;
             ResponseByteCount += 2; /* Copied this behaviour from real tag, not specified in ISO documents */
         }
         return ResponseByteCount; /* If not addressed real tag does not respond */
@@ -178,7 +178,7 @@ uint16_t EM4233_Read_Multiple(uint8_t *FrameBuf, uint16_t FrameBytes) {
     if (BlockAddress >= EM4233_NUMBER_OF_BLCKS) { /* the reader is requesting a block out of bound */
         if (FrameInfo.Addressed) { /* If the request is addressed */
             FrameBuf[ISO15693_ADDR_FLAGS] = ISO15693_RES_FLAG_ERROR;
-            FrameBuf[ISO15693_RES_ADDR_PARAM] = 0x0F; /* Magic number from real tag */
+            FrameBuf[ISO15693_RES_ADDR_PARAM] = ISO15693_RES_ERR_GENERIC;
             ResponseByteCount += 2; /* Copied this behaviour from real tag, not specified in ISO documents */
         }
         return ResponseByteCount; /* If not addressed real tag does not respond */
@@ -667,12 +667,6 @@ uint16_t EM4233AppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
         if (*FrameInfo.Command == ISO15693_CMD_RESET_TO_READY) {
             ResponseByteCount = EM4233_Reset_To_Ready(FrameBuf, FrameBytes);
         }
-    }
-
-    if (ResponseByteCount > 0) {
-        /* There is data to send. Append CRC */
-        ISO15693AppendCRC(FrameBuf, ResponseByteCount);
-        ResponseByteCount += ISO15693_CRC16_SIZE;
     }
 
     return ResponseByteCount;

--- a/Firmware/Chameleon-Mini/Application/EM4233.c
+++ b/Firmware/Chameleon-Mini/Application/EM4233.c
@@ -23,6 +23,8 @@ static enum {
 } State;
 
 bool loggedIn;
+uint8_t Uid[ISO15693_GENERIC_UID_SIZE];
+uint16_t ResponseByteCount;
 
 void EM4233AppInit(void) {
     State = STATE_READY;
@@ -35,7 +37,7 @@ void EM4233AppInit(void) {
     FrameInfo.Selected      = false;
     loggedIn = false;
     MemoryReadBlock(&MyAFI, EM4233_MEM_AFI_ADDRESS, 1);
-
+    MemoryReadBlock(&Uid, EM4233_MEM_UID_ADDRESS, ActiveConfiguration.UidSize);
 }
 
 void EM4233AppReset(void) {
@@ -48,6 +50,8 @@ void EM4233AppReset(void) {
     FrameInfo.Addressed     = false;
     FrameInfo.Selected      = false;
     loggedIn = false;
+    MemoryReadBlock(&MyAFI, EM4233_MEM_AFI_ADDRESS, 1);
+    MemoryReadBlock(&Uid, EM4233_MEM_UID_ADDRESS, ActiveConfiguration.UidSize);
 }
 
 void EM4233AppTask(void) {
@@ -59,7 +63,7 @@ void EM4233AppTick(void) {
 }
 
 uint16_t EM4233_Lock_Block(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t BlockAddress = *FrameInfo.Parameters;
     uint8_t LockStatus = 0;
 
@@ -89,7 +93,7 @@ uint16_t EM4233_Lock_Block(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Write_Single(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t BlockAddress = *FrameInfo.Parameters;
     uint8_t *Dataptr = FrameInfo.Parameters + 0x01; /* Data to write begins on 2nd byte of the frame received by the reader */
     uint8_t LockStatus = 0;
@@ -124,7 +128,7 @@ uint16_t EM4233_Write_Single(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Read_Single(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t FramePtr; /* holds the address where block's data will be put */
     uint8_t BlockAddress = FrameInfo.Parameters[0];
     uint8_t LockStatus = 0;
@@ -165,7 +169,7 @@ uint16_t EM4233_Read_Single(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Read_Multiple(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t FramePtr; /* holds the address where block's data will be put */
     uint8_t BlockAddress = FrameInfo.Parameters[0];
     uint8_t BlocksNumber = FrameInfo.Parameters[1] + 0x01; /* according to ISO standard, we have to read 0x08 blocks if we get 0x07 in request */
@@ -221,7 +225,7 @@ uint16_t EM4233_Read_Multiple(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Write_AFI(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t AFI = FrameInfo.Parameters[0];
     uint8_t LockStatus = 0;
 
@@ -248,7 +252,7 @@ uint16_t EM4233_Write_AFI(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Lock_AFI(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t LockStatus = 0;
 
     if (FrameInfo.ParamLen != 0)
@@ -275,7 +279,7 @@ uint16_t EM4233_Lock_AFI(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Write_DSFID(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t DSFID = FrameInfo.Parameters[0];
     uint8_t LockStatus = 0;
 
@@ -301,7 +305,7 @@ uint16_t EM4233_Write_DSFID(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Lock_DSFID(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t LockStatus = 0;
 
     if (FrameInfo.ParamLen != 0)
@@ -328,7 +332,7 @@ uint16_t EM4233_Lock_DSFID(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint8_t EM4233_Get_SysInfo(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t FramePtr; /* holds the address where block's data will be put */
 
     if (FrameInfo.ParamLen != 0)
@@ -351,8 +355,6 @@ uint8_t EM4233_Get_SysInfo(uint8_t *FrameBuf, uint16_t FrameBytes) {
     ResponseByteCount += 1;    /* Increment the response count */
 
     /* Then append UID */
-    uint8_t Uid[ActiveConfiguration.UidSize];
-    EM4233GetUid(Uid);
     ISO15693CopyUid(&FrameBuf[FramePtr], Uid);
     FramePtr += ISO15693_GENERIC_UID_SIZE;             /* Move forward the buffer data pointer */
     ResponseByteCount += ISO15693_GENERIC_UID_SIZE;    /* Increment the response count */
@@ -395,7 +397,7 @@ uint8_t EM4233_Get_SysInfo(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Get_Multi_Block_Sec_Stat(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t FramePtr; /* holds the address where block's data will be put */
     uint8_t BlockAddress = FrameInfo.Parameters[0];
     uint8_t BlocksNumber = FrameInfo.Parameters[1] + 0x01;
@@ -424,7 +426,7 @@ uint16_t EM4233_Get_Multi_Block_Sec_Stat(uint8_t *FrameBuf, uint16_t FrameBytes)
 }
 
 uint16_t EM4233_Select(uint8_t *FrameBuf, uint16_t FrameBytes, uint8_t *Uid) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     /* I've no idea how this request could generate errors ._.
     if ( ) {
         FrameBuf[ISO15693_ADDR_FLAGS] = ISO15693_RES_FLAG_ERROR;
@@ -460,7 +462,7 @@ uint16_t EM4233_Select(uint8_t *FrameBuf, uint16_t FrameBytes, uint8_t *Uid) {
 }
 
 uint16_t EM4233_Reset_To_Ready(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     /* I've no idea how this request could generate errors ._.
     if ( ) {
         FrameBuf[ISO15693_ADDR_FLAGS] = ISO15693_RES_FLAG_ERROR;
@@ -484,7 +486,7 @@ uint16_t EM4233_Reset_To_Ready(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Login(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     uint8_t Password[4] = { 0 };
 
     if (FrameInfo.ParamLen != 4 || !FrameInfo.Addressed || !(FrameInfo.Selected && State == STATE_SELECTED))
@@ -520,7 +522,7 @@ uint16_t EM4233_Login(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Auth1(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     // uint8_t KeyNo = *FrameInfo.Parameters; /* Right now this parameter is unused, but it will be useful */
 
     if (FrameInfo.ParamLen != 1) /* Malformed: not enough or too much data */
@@ -545,7 +547,7 @@ uint16_t EM4233_Auth1(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233_Auth2(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
     // uint8_t A2 = FrameInfo.Parameters;
     // uint8_t f = FrameInfo.Parameters + 0x08;
     // uint8_t g[3] = { 0 }; /* Names according to EM Marin definitions */
@@ -563,9 +565,7 @@ uint16_t EM4233_Auth2(uint8_t *FrameBuf, uint16_t FrameBytes) {
 }
 
 uint16_t EM4233AppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
-    uint8_t Uid[ActiveConfiguration.UidSize];
-    EM4233GetUid(Uid);
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
 
     if ((FrameBytes < ISO15693_MIN_FRAME_SIZE) || !ISO15693CheckCRC(FrameBuf, FrameBytes - ISO15693_CRC16_SIZE))
         /* malformed frame */
@@ -582,8 +582,8 @@ uint16_t EM4233AppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
         return ISO15693_APP_NO_RESPONSE;
 
     if (State == STATE_READY || State == STATE_SELECTED) {
-
-        if (*FrameInfo.Command == ISO15693_CMD_INVENTORY) {
+        switch (*FrameInfo.Command) {
+        case ISO15693_CMD_INVENTORY:
             if (FrameInfo.ParamLen == 0)
                 return ISO15693_APP_NO_RESPONSE; /* malformed: not enough or too much data */
 
@@ -593,59 +593,77 @@ uint16_t EM4233AppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
                 ISO15693CopyUid(&FrameBuf[ISO15693_RES_ADDR_PARAM + 0x01], Uid);
                 ResponseByteCount += 10;
             }
+            break;
 
-        } else if ((*FrameInfo.Command == ISO15693_CMD_STAY_QUIET) && FrameInfo.Addressed) {
-            State = STATE_QUIET;
+        case ISO15693_CMD_STAY_QUIET:
+            if (FrameInfo.Addressed)
+                State = STATE_QUIET;
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_READ_SINGLE) {
+        case ISO15693_CMD_READ_SINGLE:
             ResponseByteCount = EM4233_Read_Single(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_WRITE_SINGLE) {
+        case ISO15693_CMD_WRITE_SINGLE:
             ResponseByteCount = EM4233_Write_Single(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_LOCK_BLOCK) {
+        case ISO15693_CMD_LOCK_BLOCK:
             ResponseByteCount = EM4233_Lock_Block(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_READ_MULTIPLE) {
+        case ISO15693_CMD_READ_MULTIPLE:
             ResponseByteCount = EM4233_Read_Multiple(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_WRITE_AFI) {
+        case ISO15693_CMD_WRITE_AFI:
             ResponseByteCount = EM4233_Write_AFI(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_LOCK_AFI) {
+        case ISO15693_CMD_LOCK_AFI:
             ResponseByteCount = EM4233_Lock_AFI(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_WRITE_DSFID) {
+        case ISO15693_CMD_WRITE_DSFID:
             ResponseByteCount = EM4233_Write_DSFID(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_LOCK_DSFID) {
+        case ISO15693_CMD_LOCK_DSFID:
             ResponseByteCount = EM4233_Lock_DSFID(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_GET_SYS_INFO) {
+        case ISO15693_CMD_GET_SYS_INFO:
             ResponseByteCount = EM4233_Get_SysInfo(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_GET_BLOCK_SEC) {
+        case ISO15693_CMD_GET_BLOCK_SEC:
             ResponseByteCount = EM4233_Get_Multi_Block_Sec_Stat(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == ISO15693_CMD_RESET_TO_READY) {
+        case ISO15693_CMD_RESET_TO_READY:
             ResponseByteCount = EM4233_Reset_To_Ready(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == EM4233_CMD_LOGIN) {
+        case EM4233_CMD_LOGIN:
             ResponseByteCount = EM4233_Login(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == EM4233_CMD_AUTH1) {
+        case EM4233_CMD_AUTH1:
             ResponseByteCount = EM4233_Auth1(FrameBuf, FrameBytes);
+            break;
 
-        } else if (*FrameInfo.Command == EM4233_CMD_AUTH2) {
+        case EM4233_CMD_AUTH2:
             ResponseByteCount = EM4233_Auth2(FrameBuf, FrameBytes);
+            break;
 
-        } else {
+        default:
             if (FrameInfo.Addressed) {
                 FrameBuf[ISO15693_ADDR_FLAGS] = ISO15693_RES_FLAG_ERROR;
                 FrameBuf[ISO15693_RES_ADDR_PARAM] = ISO15693_RES_ERR_NOT_SUPP;
                 ResponseByteCount = 2;
             } /* EM4233 respond with error flag only to addressed commands */
-        }
+            break;
+}
 
     } else if (State == STATE_QUIET) {
         if (*FrameInfo.Command == ISO15693_CMD_RESET_TO_READY) {
@@ -666,6 +684,7 @@ void EM4233GetUid(ConfigurationUidType Uid) {
     MemoryReadBlock(&Uid[0], EM4233_MEM_UID_ADDRESS, ActiveConfiguration.UidSize);
 }
 
-void EM4233SetUid(ConfigurationUidType Uid) {
-    MemoryWriteBlock(Uid, EM4233_MEM_UID_ADDRESS, ActiveConfiguration.UidSize);
+void EM4233SetUid(ConfigurationUidType NewUid) {
+    memcpy(Uid, NewUid, ActiveConfiguration.UidSize);
+    MemoryWriteBlock(NewUid, EM4233_MEM_UID_ADDRESS, ActiveConfiguration.UidSize);
 }

--- a/Firmware/Chameleon-Mini/Application/EM4233.c
+++ b/Firmware/Chameleon-Mini/Application/EM4233.c
@@ -23,8 +23,6 @@ static enum {
 } State;
 
 bool loggedIn;
-uint8_t Uid[ISO15693_GENERIC_UID_SIZE];
-uint16_t ResponseByteCount;
 
 void EM4233AppInit(void) {
     State = STATE_READY;

--- a/Firmware/Chameleon-Mini/Application/ISO15693-A.c
+++ b/Firmware/Chameleon-Mini/Application/ISO15693-A.c
@@ -3,7 +3,9 @@
 #include <util/crc16.h>
 
 CurrentFrame FrameInfo;
+uint8_t Uid[ISO15693_GENERIC_UID_SIZE];
 uint8_t MyAFI;
+uint16_t ResponseByteCount;
 
 //Refer to ISO/IEC 15693-3:2001 page 41
 uint16_t calculateCRC(void *FrameBuf, uint16_t FrameBufSize) {

--- a/Firmware/Chameleon-Mini/Application/ISO15693-A.c
+++ b/Firmware/Chameleon-Mini/Application/ISO15693-A.c
@@ -2,6 +2,9 @@
 #include "../Common.h"
 #include <util/crc16.h>
 
+CurrentFrame FrameInfo;
+uint8_t MyAFI;
+
 //Refer to ISO/IEC 15693-3:2001 page 41
 uint16_t calculateCRC(void *FrameBuf, uint16_t FrameBufSize) {
     uint16_t reg = ISO15693_CRC16_PRESET;

--- a/Firmware/Chameleon-Mini/Application/ISO15693-A.h
+++ b/Firmware/Chameleon-Mini/Application/ISO15693-A.h
@@ -85,6 +85,8 @@ typedef struct {
     bool Addressed;
     bool Selected;
 } CurrentFrame;
+extern CurrentFrame FrameInfo;  /* Holds current frame information */
+extern uint8_t MyAFI;           /* Holds current tag's AFI (is used in inventory) */
 
 void ISO15693AppendCRC(uint8_t *FrameBuf, uint16_t FrameBufSize);
 bool ISO15693CheckCRC(void *FrameBuf, uint16_t FrameBufSize);

--- a/Firmware/Chameleon-Mini/Application/ISO15693-A.h
+++ b/Firmware/Chameleon-Mini/Application/ISO15693-A.h
@@ -86,7 +86,9 @@ typedef struct {
     bool Selected;
 } CurrentFrame;
 extern CurrentFrame FrameInfo;  /* Holds current frame information */
-extern uint8_t MyAFI;           /* Holds current tag's AFI (is used in inventory) */
+extern uint8_t Uid[];
+extern uint8_t MyAFI;           /* Holds current tag's AFI, used during inventory */
+extern uint16_t ResponseByteCount;  /* Length of response, used when building response frames */
 
 void ISO15693AppendCRC(uint8_t *FrameBuf, uint16_t FrameBufSize);
 bool ISO15693CheckCRC(void *FrameBuf, uint16_t FrameBufSize);

--- a/Firmware/Chameleon-Mini/Application/Reader14443A.c
+++ b/Firmware/Chameleon-Mini/Application/Reader14443A.c
@@ -19,6 +19,9 @@
 
 // TODO replace remaining magic numbers
 
+uint8_t ReaderSendBuffer[CODEC_BUFFER_SIZE];
+uint16_t ReaderSendBitCount;
+
 static bool Selected = false;
 Reader14443Command Reader14443CurrentCommand = Reader14443_Do_Nothing;
 

--- a/Firmware/Chameleon-Mini/Application/Reader14443A.h
+++ b/Firmware/Chameleon-Mini/Application/Reader14443A.h
@@ -6,8 +6,8 @@
 
 #define CRC_INIT 0x6363
 
-uint8_t ReaderSendBuffer[CODEC_BUFFER_SIZE];
-uint16_t ReaderSendBitCount;
+extern uint8_t ReaderSendBuffer[];
+extern uint16_t ReaderSendBitCount;
 
 void Reader14443AAppInit(void);
 void Reader14443AAppReset(void);

--- a/Firmware/Chameleon-Mini/Application/Sl2s2002.c
+++ b/Firmware/Chameleon-Mini/Application/Sl2s2002.c
@@ -141,12 +141,6 @@ uint16_t Sl2s2002AppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
                     break;
             }
 
-            if (ResponseByteCount > 0) {
-                /* There is data to be sent. Append CRC */
-                ISO15693AppendCRC(FrameBuf, ResponseByteCount);
-                ResponseByteCount += ISO15693_CRC16_SIZE;
-            }
-
             return ResponseByteCount;
 
         } else { // Invalid CRC

--- a/Firmware/Chameleon-Mini/Application/TITagitstandard.c
+++ b/Firmware/Chameleon-Mini/Application/TITagitstandard.c
@@ -16,10 +16,8 @@ static enum {
     STATE_QUIET
 } State;
 
-uint8_t MyAFI;                      /* Holds current tag's AFI (is used in inventory) */
 uint16_t UserLockBits_Mask = 0;     /* Holds lock state of blocks */
 uint16_t FactoryLockBits_Mask = 0;  /* Holds lock state of blocks */
-CurrentFrame FrameInfo;
 
 void TITagitstandardAppInit(void) {
     State = STATE_READY;

--- a/Firmware/Chameleon-Mini/Application/TITagitstandard.c
+++ b/Firmware/Chameleon-Mini/Application/TITagitstandard.c
@@ -18,6 +18,8 @@ static enum {
 
 uint16_t UserLockBits_Mask = 0;     /* Holds lock state of blocks */
 uint16_t FactoryLockBits_Mask = 0;  /* Holds lock state of blocks */
+uint8_t Uid[ISO15693_GENERIC_UID_SIZE];
+uint16_t ResponseByteCount;
 
 void TITagitstandardAppInit(void) {
     State = STATE_READY;
@@ -33,6 +35,7 @@ void TITagitstandardAppInit(void) {
     FrameInfo.Selected      = false;
 
     MemoryReadBlock(&MyAFI, TITAGIT_MEM_AFI_ADDRESS, 1);
+    TITagitstandardGetUid(Uid);
 }
 
 void TITagitstandardAppReset(void) {
@@ -44,6 +47,9 @@ void TITagitstandardAppReset(void) {
     FrameInfo.ParamLen      = 0;
     FrameInfo.Addressed     = false;
     FrameInfo.Selected      = false;
+
+    MemoryReadBlock(&MyAFI, TITAGIT_MEM_AFI_ADDRESS, 1);
+    TITagitstandardGetUid(Uid);
 }
 
 
@@ -56,9 +62,7 @@ void TITagitstandardAppTick(void) {
 }
 
 uint16_t TITagitstandardAppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
-    uint16_t ResponseByteCount = ISO15693_APP_NO_RESPONSE;
-    uint8_t Uid[ActiveConfiguration.UidSize];
-    TITagitstandardGetUid(Uid);
+    ResponseByteCount = ISO15693_APP_NO_RESPONSE;
 
     if ((FrameBytes < ISO15693_MIN_FRAME_SIZE) || !ISO15693CheckCRC(FrameBuf, FrameBytes - ISO15693_CRC16_SIZE))
         /* malformed frame */
@@ -213,6 +217,7 @@ void TITagitstandardGetUid(ConfigurationUidType Uid) {
 }
 
 void TITagitstandardSetUid(ConfigurationUidType Uid) {
+    memcpy(Uid, NewUid, ActiveConfiguration.UidSize); // Update the local variable
     // Reverse UID before writing it
     TITagitstandardFlipUid(Uid);
 

--- a/Firmware/Chameleon-Mini/Application/TITagitstandard.c
+++ b/Firmware/Chameleon-Mini/Application/TITagitstandard.c
@@ -18,8 +18,6 @@ static enum {
 
 uint16_t UserLockBits_Mask = 0;     /* Holds lock state of blocks */
 uint16_t FactoryLockBits_Mask = 0;  /* Holds lock state of blocks */
-uint8_t Uid[ISO15693_GENERIC_UID_SIZE];
-uint16_t ResponseByteCount;
 
 void TITagitstandardAppInit(void) {
     State = STATE_READY;
@@ -216,7 +214,7 @@ void TITagitstandardGetUid(ConfigurationUidType Uid) {
     TITagitstandardFlipUid(Uid);
 }
 
-void TITagitstandardSetUid(ConfigurationUidType Uid) {
+void TITagitstandardSetUid(ConfigurationUidType NewUid) {
     memcpy(Uid, NewUid, ActiveConfiguration.UidSize); // Update the local variable
     // Reverse UID before writing it
     TITagitstandardFlipUid(Uid);

--- a/Firmware/Chameleon-Mini/Application/TITagitstandard.c
+++ b/Firmware/Chameleon-Mini/Application/TITagitstandard.c
@@ -198,12 +198,6 @@ uint16_t TITagitstandardAppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
             break;
     }
 
-    if (ResponseByteCount > 0) {
-        /* There is data to be sent. Append CRC */
-        ISO15693AppendCRC(FrameBuf, ResponseByteCount);
-        ResponseByteCount += ISO15693_CRC16_SIZE;
-    }
-
     return ResponseByteCount;
 }
 

--- a/Firmware/Chameleon-Mini/Application/Vicinity.c
+++ b/Firmware/Chameleon-Mini/Application/Vicinity.c
@@ -92,12 +92,6 @@ uint16_t VicinityAppProcess(uint8_t *FrameBuf, uint16_t FrameBytes) {
                     break;
             }
 
-            if (ResponseByteCount > 0) {
-                /* There is data to be sent. Append CRC */
-                ISO15693AppendCRC(FrameBuf, ResponseByteCount);
-                ResponseByteCount += ISO15693_CRC16_SIZE;
-            }
-
             return ResponseByteCount;
 
         } else { // Invalid CRC

--- a/Firmware/Chameleon-Mini/Codec/Codec.c
+++ b/Firmware/Chameleon-Mini/Codec/Codec.c
@@ -24,6 +24,11 @@ static volatile struct {
 
 uint8_t CodecBuffer[CODEC_BUFFER_SIZE];
 uint8_t CodecBuffer2[CODEC_BUFFER_SIZE];
+
+void (* volatile isr_func_CODEC_TIMER_LOADMOD_CCB_VECT)(void) = NULL;
+void (* volatile isr_func_TCD0_CCC_vect)(void) = NULL;
+void (* volatile isr_func_CODEC_DEMOD_IN_INT0_VECT)(void) = NULL;
+
 // the following three functions prevent sending data directly after turning on the reader field
 void CodecReaderFieldStart(void) { // DO NOT CALL THIS FUNCTION INSIDE APPLICATION!
     if (!CodecGetReaderField() && !ReaderFieldFlags.ToBeRestarted) {

--- a/Firmware/Chameleon-Mini/Codec/Codec.h
+++ b/Firmware/Chameleon-Mini/Codec/Codec.h
@@ -117,13 +117,13 @@ extern uint8_t CodecBuffer[CODEC_BUFFER_SIZE];
 extern uint8_t CodecBuffer2[CODEC_BUFFER_SIZE];
 
 /* Shared ISR pointers and handlers */
-void (* volatile isr_func_TCD0_CCC_vect)(void);
+extern void (* volatile isr_func_TCD0_CCC_vect)(void);
 void isr_Reader14443_2A_TCD0_CCC_vect(void);
 void isr_ISO15693_CODEC_TIMER_SAMPLING_CCC_VECT(void);
-void (* volatile isr_func_CODEC_DEMOD_IN_INT0_VECT)(void);
+extern void (* volatile isr_func_CODEC_DEMOD_IN_INT0_VECT)(void);
 void isr_ISO14443_2A_TCD0_CCC_vect(void);
 void isr_ISO15693_CODEC_DEMOD_IN_INT0_VECT(void);
-void (* volatile isr_func_CODEC_TIMER_LOADMOD_CCB_VECT)(void);
+extern void (* volatile isr_func_CODEC_TIMER_LOADMOD_CCB_VECT)(void);
 void isr_ISO15693_CODEC_TIMER_LOADMOD_CCB_VECT(void);
 void isr_SniffISO14443_2A_CODEC_TIMER_LOADMOD_CCB_VECT(void);
 

--- a/Firmware/Chameleon-Mini/Codec/Codec.h
+++ b/Firmware/Chameleon-Mini/Codec/Codec.h
@@ -116,6 +116,7 @@ typedef enum {
 extern uint8_t CodecBuffer[CODEC_BUFFER_SIZE];
 extern uint8_t CodecBuffer2[CODEC_BUFFER_SIZE];
 
+/* Shared ISR pointers and handlers */
 void (* volatile isr_func_TCD0_CCC_vect)(void);
 void isr_Reader14443_2A_TCD0_CCC_vect(void);
 void isr_ISO15693_CODEC_TIMER_SAMPLING_CCC_VECT(void);

--- a/Firmware/Chameleon-Mini/Codec/ISO15693.c
+++ b/Firmware/Chameleon-Mini/Codec/ISO15693.c
@@ -258,7 +258,7 @@ ISR_SHARED isr_ISO15693_CODEC_TIMER_SAMPLING_CCC_VECT(void) {
  * It disables its own interrupt when all data has been sent
  */
 //ISR(CODEC_TIMER_LOADMOD_CCB_VECT)
-void isr_ISO15693_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
+ISR_SHARED isr_ISO15693_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
     static void *JumpTable[] = {
         [LOADMOD_START_SINGLE]  = && LOADMOD_START_SINGLE_LABEL,
         [LOADMOD_SOF_SINGLE]    = && LOADMOD_SOF_SINGLE_LABEL,

--- a/Firmware/Chameleon-Mini/Codec/ISO15693.c
+++ b/Firmware/Chameleon-Mini/Codec/ISO15693.c
@@ -88,7 +88,6 @@ static volatile uint16_t ReadCommandFromReader = 0;
  * CODEC_DEMOD_IN_PORT.INT0MASK = CODEC_DEMOD_IN_MASK0;
  * and unregistered writing the INT0MASK to 0
  */
-// ISR(CODEC_DEMOD_IN_INT0_VECT)
 ISR_SHARED isr_ISO15693_CODEC_DEMOD_IN_INT0_VECT(void) {
     /* Start sample timer CODEC_TIMER_SAMPLING (TCD0).
      * Set Counter Channel C (CCC) with relevant bitmask (TC0_CCCIF_bm),

--- a/Firmware/Chameleon-Mini/Codec/ISO15693.h
+++ b/Firmware/Chameleon-Mini/Codec/ISO15693.h
@@ -8,25 +8,7 @@
 #ifndef ISO15693_H_
 #define ISO15693_H_
 
-#include "Terminal/CommandLine.h"
-
 #define ISO15693_APP_NO_RESPONSE        0x0000
-
-#define SUBCARRIER_1                    32
-#define SUBCARRIER_2                    28
-#define SUBCARRIER_OFF                  0
-#define SOF_PATTERN                     0x1D
-#define EOF_PATTERN                     0xB8
-
-#define T1_NOMINAL_CYCLES               4352 - 14//4352 - 25 /* ISR prologue compensation */
-#define WRITE_GRID_CYCLES               4096
-
-//Used when checking the request sent from the reader
-#define ISO15693_REQ_SUBCARRIER_SINGLE  0x00
-#define ISO15693_REQ_SUBCARRIER_DUAL    0x01
-#define ISO15693_REQ_DATARATE_LOW       0x00
-#define ISO15693_REQ_DATARATE_HIGH      0x02
-
 
 /* Codec Interface */
 void ISO15693CodecInit(void);
@@ -36,7 +18,5 @@ void ISO15693CodecTask(void);
 /* Application Interface */
 void ISO15693CodecStart(void);
 void ISO15693CodecReset(void);
-
-
 
 #endif  /* ISO15693_H_ */

--- a/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.c
+++ b/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.c
@@ -56,6 +56,8 @@ static volatile uint16_t ReaderBitCount;
 static volatile uint16_t CardBitCount;
 static volatile uint16_t rawBitCount;
 
+enum RCTraffic TrafficSource;
+
 INLINE void CardSniffInit(void);
 INLINE void CardSniffDeinit(void);
 

--- a/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.c
+++ b/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.c
@@ -351,16 +351,13 @@ ISR(ACA_AC0_vect) { // this interrupt either finds the SOC or gets triggered bef
     StateRegister = PICC_FRAME;
 }
 
-ISR(CODEC_TIMER_LOADMOD_CCB_VECT) { // pause found
-    isr_func_CODEC_TIMER_LOADMOD_CCB_VECT();
-}
-
+// Called once a pause is found
 // Decode the Card -> Reader signal
 // according to the pause and modulated period
 // if the half bit duration is modulated, then add 1 to buffer
 // if the half bit duration is not modulated, then add 0 to buffer
 //ISR(CODEC_TIMER_LOADMOD_CCB_VECT) // pause found
-void isr_SniffISO14443_2A_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
+ISR_SHARED isr_SniffISO14443_2A_CODEC_TIMER_LOADMOD_CCB_VECT(void) {
     uint8_t tmp = CODEC_TIMER_TIMESTAMPS.CNTL;
     CODEC_TIMER_TIMESTAMPS.CNT = 0;
 

--- a/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.h
+++ b/Firmware/Chameleon-Mini/Codec/SniffISO14443-2A.h
@@ -9,7 +9,7 @@
 #include "Codec.h"
 #include "Terminal/CommandLine.h"
 
-enum RCTraffic {TRAFFIC_READER, TRAFFIC_CARD} TrafficSource;
+extern enum RCTraffic {TRAFFIC_READER, TRAFFIC_CARD} TrafficSource;
 /* Codec Interface */
 void Sniff14443ACodecInit(void);
 void Sniff14443ACodecDeInit(void);

--- a/Firmware/Chameleon-Mini/ISRSharing.S
+++ b/Firmware/Chameleon-Mini/ISRSharing.S
@@ -9,26 +9,24 @@
 #include "Codec/Codec.h"
 #include <avr/interrupt.h>
 
+; Use this macro to call isr functions
+.macro call_isr isr_address
+push r30
+push r31
+lds r30, \isr_address
+lds r31, \isr_address+1
+icall
+pop r31
+pop r30
+reti
+.endm
+
 ; Find first pause and start sampling
 .global CODEC_DEMOD_IN_INT0_VECT
 CODEC_DEMOD_IN_INT0_VECT:
-    push   r30
-    push   r31
-    lds    r30, isr_func_CODEC_DEMOD_IN_INT0_VECT
-    lds    r31, isr_func_CODEC_DEMOD_IN_INT0_VECT + 1
-    icall
-    pop    r31
-    pop    r30
-    reti
+    call_isr isr_func_CODEC_DEMOD_IN_INT0_VECT
 
 ; Frame Delay Time PCD to PICC ends
 .global CODEC_TIMER_SAMPLING_CCC_VECT
 CODEC_TIMER_SAMPLING_CCC_VECT:
-    push   r30
-    push   r31
-    lds    r30, isr_func_TCD0_CCC_vect
-    lds    r31, isr_func_TCD0_CCC_vect + 1
-    icall
-    pop    r31
-    pop    r30
-    reti
+    call_isr isr_func_TCD0_CCC_vect

--- a/Firmware/Chameleon-Mini/ISRSharing.S
+++ b/Firmware/Chameleon-Mini/ISRSharing.S
@@ -10,12 +10,13 @@
 #include <avr/interrupt.h>
 
 ; Macro to call ISR functions
+; For development purposes: cycles penality before landing in the Shared ISR is 10
 .macro call_isr isr_address
-push r30
-push r31
-lds r30, \isr_address
-lds r31, \isr_address+1
-icall
+push r30                    ; 1
+push r31                    ; 1
+lds r30, \isr_address       ; 3
+lds r31, \isr_address+1     ; 3
+icall                       ; 2 (16 bit PC)
 pop r31
 pop r30
 reti

--- a/Firmware/Chameleon-Mini/ISRSharing.S
+++ b/Firmware/Chameleon-Mini/ISRSharing.S
@@ -32,22 +32,17 @@ reti
 ; INTERRUPT-TO-SHARE
 ;   The target interrupt which needs to be shared
 ; POINTER-TO-VARIABLE-INTERRUPT-HANDLER
-;   A pointer to the current interrupt handler which can be modified
-;   at runtime. Must be a volatile pointer to function defined in Codec.h
+;   A pointer to the interrupt handler which can be modified at runtime.
+;   Must be a volatile pointer to function declared in Codec.h
 
-; TODO spostare i commenti qui sotto alle funzioni appropriate. Non ha senso commentare i nomi dei vettori, ma bisogna commentare la funzione nel contesto
-; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-; Sample reader field and demodulate signal after first pause
 .global CODEC_DEMOD_IN_INT0_VECT
 CODEC_DEMOD_IN_INT0_VECT:
     call_isr isr_func_CODEC_DEMOD_IN_INT0_VECT
 
-; Frame Delay Time PCD to PICC ends
 .global CODEC_TIMER_SAMPLING_CCC_VECT
 CODEC_TIMER_SAMPLING_CCC_VECT:
     call_isr isr_func_TCD0_CCC_vect
 
-; Send response data from emulated card to reader
 .global CODEC_TIMER_LOADMOD_CCB_VECT
 CODEC_TIMER_LOADMOD_CCB_VECT:
     call_isr isr_func_CODEC_TIMER_LOADMOD_CCB_VECT

--- a/Firmware/Chameleon-Mini/ISRSharing.S
+++ b/Firmware/Chameleon-Mini/ISRSharing.S
@@ -9,7 +9,7 @@
 #include "Codec/Codec.h"
 #include <avr/interrupt.h>
 
-; Use this macro to call isr functions
+; Macro to call ISR functions
 .macro call_isr isr_address
 push r30
 push r31
@@ -21,7 +21,23 @@ pop r30
 reti
 .endm
 
-; Find first pause and start sampling
+; Shared ISR must be defined below as globals
+; Example:
+;
+; .global <INTERRUPT-TO-SHARE>
+; INTERRUPT-TO-SHARE:
+;     call_isr POINTER-TO-VARIABLE-INTERRUPT-HANDLER
+;
+; Where:
+; INTERRUPT-TO-SHARE
+;   The target interrupt which needs to be shared
+; POINTER-TO-VARIABLE-INTERRUPT-HANDLER
+;   A pointer to the current interrupt handler which can be modified
+;   at runtime. Must be a volatile pointer to function defined in Codec.h
+
+; TODO spostare i commenti qui sotto alle funzioni appropriate. Non ha senso commentare i nomi dei vettori, ma bisogna commentare la funzione nel contesto
+; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+; Sample reader field and demodulate signal after first pause
 .global CODEC_DEMOD_IN_INT0_VECT
 CODEC_DEMOD_IN_INT0_VECT:
     call_isr isr_func_CODEC_DEMOD_IN_INT0_VECT
@@ -30,3 +46,8 @@ CODEC_DEMOD_IN_INT0_VECT:
 .global CODEC_TIMER_SAMPLING_CCC_VECT
 CODEC_TIMER_SAMPLING_CCC_VECT:
     call_isr isr_func_TCD0_CCC_vect
+
+; Send response data from emulated card to reader
+.global CODEC_TIMER_LOADMOD_CCB_VECT
+CODEC_TIMER_LOADMOD_CCB_VECT:
+    call_isr isr_func_CODEC_TIMER_LOADMOD_CCB_VECT

--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -15,6 +15,7 @@
 #include "../AntennaLevel.h"
 #include "../Battery.h"
 #include "../Codec/Codec.h"
+#include "../Application/Reader14443A.h"
 
 extern Reader14443Command Reader14443CurrentCommand;
 extern Sniff14443Command Sniff14443CurrentCommand;


### PR DESCRIPTION
This PR includes and supersedes https://github.com/emsec/ChameleonMini/pull/272

Me and @MrMoDDoM have been refining ISO15 code due to an issue we faced with the ST CR95HF reader. We thought something was wrong with the codec because the Read Multiple Blocks failed when reading more than 7 blocks at once. It felt like an issue when modulating long frames but, after some investigation it turned out that the ST reader was very precise with SOF timings.
Reading more than 7 blocks into the codec's buffer take too much time, and this means that ISO t1 time elapses before data is ready and the codec is stuck waiting for data before it can modulate anything, so the reader complains as it did not receive a SOF in time. This kind of issues is not present with the phones we've tested the code with

I'd like to discuss about ISO t1 time, since we could not explain how the old value ```4192 + 128 + 128 - 1``` was chosen. This value is greater than both ISO dictated nominal and maximum t1, but yielded better results than t1 nominal, so reading 10 blocks at a time was possible. This is possibly due to the fact that waiting "a bit more" allows the Application to generate needed data before the first interrupt hit occurs and, at that time, data is marked as ready to be processed by CodecTask.
How was the old value chosen? Do we want to favor performance over emulation accuracy? Which value should be kept?

Also, applications were updated to improve performance. Reading the UID on every ApplicationTask hit was totally unnecessary and a big performance drag