### PR TITLE
Introduce automated builds with Github Actions

### DIFF
--- a/.github/workflows/firmware-pr.yml
+++ b/.github/workflows/firmware-pr.yml
@@ -1,0 +1,36 @@
+name: Firmware Build (Pull Request, Firmware Modified, Artifact in build job)
+
+on:
+  pull_request:
+    paths:
+      - "Firmware/**"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Make a firmware build folder
+      run: mkdir FirmwareBuild
+    - name: Print Kernel Ver
+      run: uname -a
+    - name: Update APT
+      run: sudo apt-get update -yqq
+    - name: Install AVR GCC Suite
+      run: sudo apt-get install -yqq make autoconf build-essential ca-certificates pkg-config libreadline-dev gcc-avr binutils-avr gdb-avr avr-libc avrdude
+    - name: Make Firmware
+      run: make
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Move hex file to FirmwareBuild
+      run: mv Chameleon*.hex $GITHUB_WORKSPACE/FirmwareBuild/
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Move eep file to FirmwareBuild
+      run: mv Chameleon*.eep $GITHUB_WORKSPACE/FirmwareBuild/
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Upload Build Artifact to Action
+      uses: actions/upload-artifact@v2.1.4
+      with:
+        name: "ChameleonBuild"
+        path: "FirmwareBuild/**"

--- a/.github/workflows/firmware-push.yml
+++ b/.github/workflows/firmware-push.yml
@@ -1,0 +1,52 @@
+name: Firmware Build (master Branch Push, Pre-release with Artifacts)
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Make a firmware build folder
+      run: mkdir FirmwareBuild
+    - name: Print Kernel Ver
+      run: uname -a
+    - name: Update APT
+      run: sudo apt-get update -yqq
+    - name: Install AVR GCC Suite
+      run: sudo apt-get install -yqq make autoconf build-essential ca-certificates pkg-config libreadline-dev gcc-avr binutils-avr gdb-avr avr-libc avrdude
+    - name: Make Firmware
+      run: make
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Move hex file to FirmwareBuild
+      run: mv Chameleon*.hex $GITHUB_WORKSPACE/FirmwareBuild/
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Move eep file to FirmwareBuild
+      run: mv Chameleon*.eep $GITHUB_WORKSPACE/FirmwareBuild/
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Upload Build Artifact to Action
+      uses: actions/upload-artifact@v2.1.4
+      with:
+        name: "ChameleonBuild"
+        path: "FirmwareBuild/**"
+    - name: Create a Pre-release
+      uses: actions/create-release@v1.1.3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: "${{ format('Build-{0}', github.sha) }}"
+        release_name: Firmware Build ${{ github.sha }}
+        body: Built at commit ${{ github.sha }} from ${{ github.actor }}
+        draft: false
+        prerelease: true
+    - name: Upload Pre-release Artifacts
+      uses: linuxgemini/github-upload-release-artifacts-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        created_tag: "${{ format('Build-{0}', github.sha) }}"
+        args: "FirmwareBuild/"


### PR DESCRIPTION
Introduces changes sent to https://github.com/RfidResearchGroup/ChameleonMini/pull/38 and https://github.com/RfidResearchGroup/ChameleonMini/pull/39

This PR seperates the actions for `master` branch pushes and pull requests.

All pushes to the `master` branch will be built. The action will make a Pre-release with the firmware files attached. These will be available at https://github.com/emsec/ChameleonMini/releases

All pull requests will still be built. However they won't be tagged with a Pre-release. Firmware files is accessible on the action job page. These will be available under each job at https://github.com/emsec/ChameleonMini/actions?query=workflow%3A%22Firmware+Build+%28Pull+Request%2C+Firmware+Modified%2C+Artifact+in+build+job%29%22