### PR TITLE
Fixes to LiveLogTick function, memory bounds checking, and optimizations to save memory space requirements in the firmware

### DIFF
--- a/Firmware/Chameleon-Mini/LiveLogTick.h
+++ b/Firmware/Chameleon-Mini/LiveLogTick.h
@@ -25,13 +25,13 @@
 #ifndef FLUSH_LOGS_ON_SPACE_ERROR
 #define FLUSH_LOGS_ON_SPACE_ERROR       (1)
 #endif
-
 typedef struct LogBlockListNode {
-    uint8_t                  *logBlockStart;
-    uint8_t                  logBlockSize;
-    struct LogBlockListNode  *nextBlock;
+     uint8_t                  *logBlockDataStart;
+     uint8_t                  logBlockDataSize;
+     struct LogBlockListNode  *nextBlock;
 } LogBlockListNode;
 
+#define LOG_BLOCK_LIST_NODE_SIZE             (sizeof(LogBlockListNode) + 4 - (uint8_t) (sizeof(LogBlockListNode) % 4))
 extern LogBlockListNode *LogBlockListBegin;
 extern LogBlockListNode *LogBlockListEnd;
 extern uint8_t LogBlockListElementCount;
@@ -44,75 +44,81 @@ INLINE void FreeLogBlocks(void);
 INLINE bool AtomicLiveLogTick(void);
 INLINE bool LiveLogTick(void);
 
-INLINE bool
+INLINE bool 
 AtomicAppendLogBlock(LogEntryEnum logCode, uint16_t sysTickTime, const uint8_t *logData, uint8_t logDataSize) {
-    bool status = true;
-    if ((logDataSize + 4 > LogMemLeft) && (LogMemPtr != LogMem)) {
-        if (FLUSH_LOGS_ON_SPACE_ERROR) {
-            LiveLogTick();
-            FreeLogBlocks();
-        }
-        status = false;
-    } else if (logDataSize + 4 <= LogMemLeft) {
-        LogBlockListNode *logBlock = (LogBlockListNode *) malloc(sizeof(LogBlockListNode));
-        logBlock->logBlockStart = LogMemPtr;
-        logBlock->logBlockSize = logDataSize + 4;
-        logBlock->nextBlock = NULL;
-        *(LogMemPtr++) = logCode;
-        *(LogMemPtr++) = logDataSize;
-        *(LogMemPtr++) = (uint8_t)(sysTickTime >> 8);
-        *(LogMemPtr++) = (uint8_t)(sysTickTime >> 0);
-        memcpy(LogMemPtr, logData, logDataSize);
-        LogMemPtr += logDataSize;
-        LogMemLeft -= logDataSize + 4;
-        if (LogBlockListBegin != NULL && LogBlockListEnd != NULL) {
-            LogBlockListEnd->nextBlock = logBlock;
-            LogBlockListEnd = logBlock;
-        } else {
-            LogBlockListBegin = LogBlockListEnd = logBlock;
-        }
-        ++LogBlockListElementCount;
-    } else {
-        status = false;
-    }
-    return status;
+     bool status = true;
+     if((logDataSize + 4 + 3 + LOG_BLOCK_LIST_NODE_SIZE > LogMemLeft) && (LogMemPtr != LogMem)) {
+          if(FLUSH_LOGS_ON_SPACE_ERROR) {
+              LiveLogTick();
+              FreeLogBlocks();
+          }
+          status = false;
+     }
+     else if(logDataSize + 4 + 3 + LOG_BLOCK_LIST_NODE_SIZE <= LogMemLeft) {
+         uint8_t alignOffset = 4 - (uint8_t) (((uint16_t) LogMemPtr) % 4);
+         uint8_t *logBlockStart = LogMemPtr + alignOffset;
+         LogBlockListNode logBlock;
+         LogMemPtr += LOG_BLOCK_LIST_NODE_SIZE + alignOffset;
+         LogMemLeft -= LOG_BLOCK_LIST_NODE_SIZE + alignOffset;
+         logBlock.logBlockDataStart = LogMemPtr;
+         logBlock.logBlockDataSize = logDataSize + 4;
+         logBlock.nextBlock = 0;
+         *(LogMemPtr++) = (uint8_t) logCode;
+         *(LogMemPtr++) = logDataSize;
+         *(LogMemPtr++) = (uint8_t) (sysTickTime >> 8);
+         *(LogMemPtr++) = (uint8_t) (sysTickTime >> 0);
+         memcpy(LogMemPtr, logData, logDataSize);
+         LogMemPtr += logDataSize;
+         LogMemLeft -= logDataSize + 4;
+         memcpy(logBlockStart, &logBlock, sizeof(LogBlockListNode));
+         if(LogBlockListBegin != NULL && LogBlockListEnd != NULL) {
+              LogBlockListEnd->nextBlock = (LogBlockListNode *) logBlockStart;
+              LogBlockListEnd = (LogBlockListNode *) logBlockStart;
+         }
+         else {
+             LogBlockListBegin = LogBlockListEnd = (LogBlockListNode *) logBlockStart;
+         }
+         ++LogBlockListElementCount;
+     }
+     else {
+         status = false;
+     }
+     return status;
 }
 
 INLINE void
 FreeLogBlocks(void) {
-    LogMemPtr = &LogMem[0];
-    LogBlockListNode *logBlockCurrent = LogBlockListBegin;
-    LogBlockListNode *logBlockNext = NULL;
-    while (logBlockCurrent != NULL) {
-        logBlockNext = logBlockCurrent->nextBlock;
-        LogMemLeft += logBlockCurrent->logBlockSize;
-        free(logBlockCurrent);
-        logBlockCurrent = logBlockNext;
-    }
-    LogBlockListBegin = LogBlockListEnd = NULL;
-    LogBlockListElementCount = 0;
+      LogMemPtr = &LogMem[0];
+      LogMemLeft = LOG_SIZE;
+      LogBlockListBegin = LogBlockListEnd = NULL;
+      LogBlockListElementCount = 0;
 }
 
 INLINE bool
 AtomicLiveLogTick(void) {
-    bool status;
-    status = LiveLogTick();
-    return status;
+     return LiveLogTick();
 }
 
 INLINE bool
 LiveLogTick(void) {
-    bool status = LogBlockListBegin == NULL;
-    LogBlockListNode *logBlockCurrent = LogBlockListBegin;
-    while (logBlockCurrent != NULL && LogBlockListElementCount > 0) {
-        TerminalFlushBuffer();
-        TerminalSendBlock(logBlockCurrent->logBlockStart, logBlockCurrent->logBlockSize);
-        TerminalFlushBuffer();
-        logBlockCurrent = logBlockCurrent->nextBlock;
-    }
-    FreeLogBlocks();
-    LiveLogModePostTickCount = 0x00;
-    return status;
+     LogBlockListNode logBlockCurrent, *tempBlockPtr = NULL;
+     memcpy(&logBlockCurrent, LogBlockListBegin, sizeof(LogBlockListNode));
+     while(LogBlockListElementCount > 0) {
+         TerminalFlushBuffer();
+         TerminalSendBlock(logBlockCurrent.logBlockDataStart, logBlockCurrent.logBlockDataSize);
+         TerminalFlushBuffer();
+         tempBlockPtr = logBlockCurrent.nextBlock;
+         if(tempBlockPtr != NULL) {
+              memcpy(&logBlockCurrent, tempBlockPtr, sizeof(LogBlockListNode));
+         }
+         else {
+              break;
+         }
+         --LogBlockListElementCount;
+     }
+     FreeLogBlocks();
+     LiveLogModePostTickCount = 0;
+     return true;
 }
 
 #endif

--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -7,18 +7,18 @@ SHELL = /bin/sh
 #Supported configurations
 SETTINGS    += -DCONFIG_MF_CLASSIC_MINI_4B_SUPPORT
 SETTINGS    += -DCONFIG_MF_CLASSIC_1K_SUPPORT
-SETTINGS    += -DCONFIG_MF_CLASSIC_1K_7B_SUPPORT
+#SETTINGS    += -DCONFIG_MF_CLASSIC_1K_7B_SUPPORT
 SETTINGS    += -DCONFIG_MF_CLASSIC_4K_SUPPORT
-SETTINGS    += -DCONFIG_MF_CLASSIC_4K_7B_SUPPORT
+#SETTINGS    += -DCONFIG_MF_CLASSIC_4K_7B_SUPPORT
 SETTINGS    += -DCONFIG_MF_ULTRALIGHT_SUPPORT
 SETTINGS	+= -DCONFIG_ISO14443A_SNIFF_SUPPORT
 SETTINGS	+= -DCONFIG_ISO14443A_READER_SUPPORT
-SETTINGS	+= -DCONFIG_NTAG215_SUPPORT
-SETTINGS	+= -DCONFIG_VICINITY_SUPPORT
-SETTINGS	+= -DCONFIG_SL2S2002_SUPPORT
-SETTINGS	+= -DCONFIG_TITAGITSTANDARD_SUPPORT
+#SETTINGS	+= -DCONFIG_NTAG215_SUPPORT
+#SETTINGS	+= -DCONFIG_VICINITY_SUPPORT
+#SETTINGS	+= -DCONFIG_SL2S2002_SUPPORT
+#SETTINGS	+= -DCONFIG_TITAGITSTANDARD_SUPPORT
 SETTINGS	+= -DCONFIG_ISO15693_SNIFF_SUPPORT
-SETTINGS	+= -DCONFIG_EM4233_SUPPORT
+#SETTINGS	+= -DCONFIG_EM4233_SUPPORT
 
 #Support magic mode on mifare classic configuration
 SETTINGS	+= -DSUPPORT_MF_CLASSIC_MAGIC_MODE
@@ -78,8 +78,10 @@ SETTINGS	+= -DDEFAULT_READER_THRESHOLD=400
 SETTINGS	+= -DENABLE_EEPROM_SETTINGS
 
 #Memory definitions and objcopy flags to include sections in binaries
+#FLASH_DATA_ADDR = 0x10000 #Start of data section in flash
+#FLASH_DATA_SIZE = 0x10000 #Size of data section in flash
 FLASH_DATA_ADDR = 0x10000 #Start of data section in flash
-FLASH_DATA_SIZE = 0x10000 #Size of data section in flash
+FLASH_DATA_SIZE = 0x0FFFF #Size of data section in flash
 FLASH_DATA_OBJCOPY = --set-section-flags=.flashdata="alloc,load"
 SPM_HELPER_ADDR = 0x21FE0 #Start of SPM helper section. Should be last 32Byte in bootloader section
 SPM_HELPER_OBJCOPY = --set-section-flags=.spmhelper="alloc,load"
@@ -107,10 +109,13 @@ SRC         += Codec/ISO15693.c
 SRC         += Application/Vicinity.c Application/Sl2s2002.c Application/TITagitstandard.c Application/ISO15693-A.c Application/EM4233.c
 SRC         += $(LUFA_SRC_USB) $(LUFA_SRC_USBCLASS)
 LUFA_PATH    = ../LUFA
-CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR) -DFLASH_DATA_SIZE=$(FLASH_DATA_SIZE) \
+CC_FLAGS     = -g0 -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR) -DFLASH_DATA_SIZE=$(FLASH_DATA_SIZE) \
 			   -DSPM_HELPER_ADDR=$(SPM_HELPER_ADDR) -DBUILD_DATE=$(BUILD_DATE) -DCOMMIT_ID=\"$(COMMIT_ID)\" $(SETTINGS) \
 			   -D__AVR_ATxmega128A4U__ -D__PROG_TYPES_COMPAT__ -DMAX_ENDPOINT_INDEX=4 \
-			   -std=gnu99 -Werror=implicit-function-declaration
+			   -std=gnu99 -Werror=implicit-function-declaration \
+			   -fno-inline-small-functions -fshort-enums -fpack-struct \
+                  -ffunction-sections -Wl,--gc-sections --data-sections -ffunction-sections \
+                  -Wl,-relax -fno-split-wide-types -fno-tree-scev-cprop
 LD_FLAGS     = $(CC_FLAGS) -Wl,--section-start=.flashdata=$(FLASH_DATA_ADDR) -Wl,--section-start=.spmhelper=$(SPM_HELPER_ADDR)
 OBJDIR       = Bin
 OBJECT_FILES =
@@ -131,7 +136,6 @@ AVRDUDE_WRITE_EEPROM_LATEST = -U eeprom:w:Latest/Chameleon-Mini.eep
 
 # Default target
 all:
-	$(CROSS)-size --mcu=atmega128 -C $(TARGET).elf
 
 # Include LUFA build script makefiles
 include $(LUFA_PATH)/Build/lufa_core.mk

--- a/Firmware/Chameleon-Mini/Memory.c
+++ b/Firmware/Chameleon-Mini/Memory.c
@@ -362,11 +362,28 @@ void MemoryReadBlock(void *Buffer, uint16_t Address, uint16_t ByteCount) {
     FRAMRead(Buffer, Address, ByteCount);
 }
 
+void MemoryReadBlockInSetting(void* Buffer, uint16_t Address, uint16_t ByteCount)
+{
+    if (ByteCount == 0 || Address >= MEMORY_SIZE_PER_SETTING)
+        return;
+    uint16_t ActualFRAMAddress = Address + GlobalSettings.ActiveSettingIdx * MEMORY_SIZE_PER_SETTING;
+    FRAMRead(Buffer, ActualFRAMAddress, ByteCount);
+}
+
 void MemoryWriteBlock(const void *Buffer, uint16_t Address, uint16_t ByteCount) {
     if (ByteCount == 0)
         return;
     FRAMWrite(Buffer, Address, ByteCount);
 
+    LEDHook(LED_MEMORY_CHANGED, LED_ON);
+}
+
+void MemoryWriteBlockInSetting(const void* Buffer, uint16_t Address, uint16_t ByteCount)
+{
+    if (ByteCount == 0 || Address >= MEMORY_SIZE_PER_SETTING)
+        return;
+    uint16_t ActualFRAMAddress = Address + GlobalSettings.ActiveSettingIdx * MEMORY_SIZE_PER_SETTING;
+    FRAMWrite(Buffer, ActualFRAMAddress, ByteCount);
     LEDHook(LED_MEMORY_CHANGED, LED_ON);
 }
 

--- a/Firmware/Chameleon-Mini/Memory.h
+++ b/Firmware/Chameleon-Mini/Memory.h
@@ -16,8 +16,10 @@
 #include "Common.h"
 
 void MemoryInit(void);
-void MemoryReadBlock(void *Buffer, uint16_t Address, uint16_t ByteCount);
-void MemoryWriteBlock(const void *Buffer, uint16_t Address, uint16_t ByteCount);
+void MemoryReadBlock(void* Buffer, uint16_t Address, uint16_t ByteCount);
+void MemoryReadBlockInSetting(void* Buffer, uint16_t Address, uint16_t ByteCount);
+void MemoryWriteBlock(const void* Buffer, uint16_t Address, uint16_t ByteCount);
+void MemoryWriteBlockInSetting(const void* Buffer, uint16_t Address, uint16_t ByteCount);
 void MemoryClear(void);
 
 


### PR DESCRIPTION
After some discussion with @ceres-c summarized in #284 (with possible build configuration solutions in #283), the standard firmware binary that resulted before used too much memory. This seems to be the cause of several recent issues and unpredictable crashes running the firmware. I looked at this today and found some fixes that help. Note that with these changes the newly compiled binary yields:
```bash
$ avr-size -t Chameleon-Mini.elf
   text	   data	    bss	    dec	    hex	filename
  56424	   1288	   4716	  62428	   f3dc	Chameleon-Mini.elf
  56424	   1288	   4716	  62428	   f3dc	(TOTALS)
```
The last numeric column is noted to not exceed ``0x10000``. 

A complete summary of all the changes contained in this pull request are given below: 
* **Change in the implementation of LiveLogTick:** In #279, this functionality was merged. It included small numbers of dynamic allocation of memory space via ``malloc/free``. This is typically not good practice on memory constrained devices, and pulls in extra memory requirements. I rewrote the core of the ``LiveLogTick.h`` sources to store the linked list node structures in the ``LogMem`` buffer (along with the temporary contents of logs). The solution removes the need for the dynamic memory alloc/dealloc functions from GLibC. It also seems to fix some oversights in the original code based on testing. Notice that every position for the structure pointer addresses needs to be an even multiple of four.
* **A couple of new FRAM memory R/W functions:** Added ``MemoryReadBlockInSetting`` and ``MemoryWriteBlockInSetting`` that tag implementations can call to safely write to the FRAM space for their slot. These check an upper bound on the size of the block address, and add an offset into FRAM based on the slot index. In contrast, the original two functions do not ignore unintentional memory boundary errors and do not shift the block address by the slot index offset. 
* **Makefile changes:** The added flags, and the change of value of the ``FLASH_DATA_SIZE`` option reflects the noise and discussion from yesterday. Nothing fancy, just compiler optimizations to make the memory imposed on the AVR less bloated. 
