### PR TITLE
Updating and adding new support for DES and AES-128 crypto with HW acceleration

### DIFF
--- a/Firmware/Chameleon-Mini/Application/CryptoAES128.c
+++ b/Firmware/Chameleon-Mini/Application/CryptoAES128.c
@@ -1,0 +1,384 @@
+/* CryptoAES128.c : Adds support for XMega HW accelerated 128-bit AES encryption 
+ *                  in ECB and CBC modes. 
+ *                  Based in part on the the source code for Microchip's ASF library 
+ *                  available at https://github.com/avrxml/asf (see license below). 
+ * Author: Maxie D. Schmidt (@maxieds) 
+ */
+
+/*****************************************************************************
+ * Copyright (c) 2014-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *****************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include <avr/interrupt.h>
+
+#include "CryptoAES128.h"
+
+#define NOP()	__asm__ __volatile__("nop")
+
+/* AES interrupt callback function pointer. */
+static aes_callback_t __CryptoAESCallbackFunc = NULL;
+
+/* Keep track of the last IV block data */
+static CryptoAESBlock_t __CryptoAES_IVData = { 0 };
+
+/* Set the last operation mode (ECB or CBC) init for the context */
+static uint8_t __CryptoAESOpMode = CRYPTO_AES_CBC_MODE;
+
+void aes_start(void) {
+	AES.CTRL |= AES_START_bm;
+}
+
+void aes_software_reset(void) {
+	AES.CTRL = AES_RESET_bm;
+}
+
+bool aes_is_busy(void) {
+	return !(AES.STATUS & (AES_SRIF_bm | AES_ERROR_bm));
+}
+
+bool aes_is_error(void) {
+	return (AES.STATUS & AES_ERROR_bm);
+}
+
+void aes_clear_interrupt_flag(void) {
+	AES.STATUS |= AES_SRIF_bm;
+}
+
+void aes_clear_error_flag(void) {
+	AES.STATUS |= AES_ERROR_bm;
+}
+
+void aes_configure(CryptoAESDec_t op_mode, CryptoAESAuto_t auto_start, CryptoAESXor_t xor_mode) {
+     AES.CTRL = ((uint8_t) op_mode | (uint8_t) auto_start | (uint8_t) xor_mode);
+}
+
+void aes_configure_encrypt(CryptoAESAuto_t auto_start, CryptoAESXor_t xor_mode) {
+     aes_configure(AES_ENCRYPT, auto_start, xor_mode);
+}
+
+void aes_configure_decrypt(CryptoAESAuto_t auto_start, CryptoAESXor_t xor_mode) {
+     aes_configure(AES_DECRYPT, auto_start, xor_mode);
+}
+
+void aes_set_key(uint8_t *key_in) {
+     uint8_t i;
+	uint8_t *temp_key = key_in;
+	for (i = 0; i < CRYPTO_AES_KEY_SIZE; i++) {
+		AES.KEY = *(temp_key++);
+	}
+}
+
+void aes_get_key(uint8_t *key_out) {
+     uint8_t i;
+	uint8_t *temp_key = key_out;
+	for (i = 0; i < CRYPTO_AES_KEY_SIZE; i++) {
+		*(temp_key++) = AES.KEY;
+	}
+}
+
+static bool aes_lastsubkey_generate(uint8_t *key, uint8_t *last_sub_key) {
+	bool keygen_ok;
+	aes_software_reset();
+	/* Load dummy data into AES state memory. It isn't important what is
+	 * written, just that a write cycle occurs. */
+	uint8_t dummy_data[] = {
+	     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+     };
+     CryptoAESEncryptBlock(dummy_data, dummy_data, key, false);
+	/* If not error. */
+	if (!aes_is_error()) {
+		/* Store the last subkey. */
+		aes_get_key(last_sub_key);
+		aes_clear_interrupt_flag();
+		keygen_ok = true;
+	} else {
+		aes_clear_error_flag();
+		keygen_ok = false;
+	}
+	return keygen_ok;
+}
+
+void aes_write_inputdata(uint8_t *data_in) {
+     uint8_t i;
+	uint8_t *temp_state = data_in;
+	for (i = 0; i < CRYPTO_AES_BLOCK_SIZE; i++) {
+		AES.STATE = *(temp_state++);
+	}
+}
+
+void aes_read_outputdata(uint8_t *data_out) {
+     uint8_t i;
+	uint8_t *temp_state = data_out;
+	for (i = 0; i < CRYPTO_AES_BLOCK_SIZE; i++) {
+		*(temp_state++) = AES.STATE;
+	}
+}
+
+void aes_isr_configure(CryptoAESIntlvl_t intlvl) {
+     /* Remove pending AES interrupts. */
+	AES.STATUS = (AES_ERROR_bm | AES_SRIF_bm);
+	AES.INTCTRL = intlvl;
+}
+
+void aes_set_callback(const aes_callback_t callback) {
+     __CryptoAESCallbackFunc = callback;
+}
+
+ISR(AES_INT_vect) {
+	if (__CryptoAESCallbackFunc != NULL){
+		__CryptoAESCallbackFunc();
+	}
+}
+
+void CryptoAESGetConfigDefaults(CryptoAESConfig_t *ctx) {
+     if(ctx == NULL) {
+          return;
+     }
+     ctx->ProcessingMode = CRYPTO_AES_PMODE_ENCIPHER;
+     ctx->ProcessingDelay = 0;
+     ctx->StartMode = AES_MANUAL;
+     ctx->OpMode = CRYPTO_AES_CBC_MODE;
+     ctx->XorMode = AES_XOR_ON;
+}
+
+static void int_callback_aes(void) {}
+
+void CryptoAESInitContext(CryptoAESConfig_t *ctx) { 
+     if(ctx == NULL) {
+          return; 
+     }
+     aes_software_reset();
+     memset(__CryptoAES_IVData, 0x00, CRYPTO_AES_BLOCK_SIZE);
+     __CryptoAESOpMode = ctx->OpMode;
+     aes_configure(ctx->ProcessingMode, ctx->StartMode, ctx->XorMode);
+     aes_set_callback(&int_callback_aes);
+}
+
+uint16_t CryptoAESGetPaddedBufferSize(uint16_t bufSize) {
+     uint16_t spareBytes = (bufSize % CRYPTO_AES_BLOCK_SIZE);
+     if(spareBytes == 0) {
+          return bufSize;
+     }   
+     return bufSize + CRYPTO_AES_BLOCK_SIZE - spareBytes;
+}
+
+void CryptoAESEncryptBlock(uint8_t *Plaintext, uint8_t *Ciphertext, const uint8_t *Key, bool XorModeOn) {
+     aes_software_reset();
+     AES.CTRL = AES_RESET_bm;
+	NOP();
+	AES.CTRL = 0;
+     aes_configure_encrypt(AES_MANUAL, XorModeOn ? AES_XOR_ON : AES_XOR_OFF);
+     aes_isr_configure(AES_INTLVL_LO);
+     aes_set_key(Key);
+	for (uint8_t i = 0; i < CRYPTO_AES_BLOCK_SIZE; i++) {
+		AES.STATE = 0x00;
+     }
+     aes_write_inputdata(Plaintext);
+	aes_start();
+	do {
+	     // Wait until AES is finished or an error occurs.
+	} while (aes_is_busy());
+	aes_read_outputdata(Ciphertext);
+     aes_clear_interrupt_flag();
+     aes_clear_error_flag();
+}
+
+void CryptoAESDecryptBlock(uint8_t *Plaintext, uint8_t *Ciphertext, const uint8_t *Key) {
+     AES.CTRL = AES_RESET_bm;
+	NOP();
+	AES.CTRL = 0;
+     uint8_t lastSubKey[CRYPTO_AES_KEY_SIZE];
+     aes_lastsubkey_generate(Key, lastSubKey);
+     AES.CTRL = AES_RESET_bm;
+	NOP();
+	AES.CTRL = 0;
+     aes_configure_decrypt(AES_MANUAL, AES_XOR_OFF);
+     aes_isr_configure(AES_INTLVL_LO);
+     aes_set_key(lastSubKey);
+     for (uint8_t i = 0; i < CRYPTO_AES_BLOCK_SIZE; i++) {
+		AES.STATE = 0x00;
+     }
+     aes_write_inputdata(Ciphertext);
+	aes_start();
+	do {
+	     // Wait until AES is finished or an error occurs.
+	} while (aes_is_busy());
+	aes_read_outputdata(Plaintext);
+     aes_clear_interrupt_flag();
+     aes_clear_error_flag();
+}
+
+uint8_t CryptoAESEncryptBuffer(uint16_t Count, uint8_t *Plaintext, uint8_t *Ciphertext,
+                               const uint8_t *IV, const uint8_t *Key) {
+     if((Count % CRYPTO_AES_BLOCK_SIZE) != 0) {
+          return 0xBE;
+     }
+     else if(IV == NULL) {
+          memset(__CryptoAES_IVData, 0x00, CRYPTO_AES_BLOCK_SIZE);     
+          IV = &__CryptoAES_IVData[0];
+     }
+     size_t bufBlocks = (Count + CRYPTO_AES_BLOCK_SIZE - 1) / CRYPTO_AES_BLOCK_SIZE;
+     for(int blk = 0; blk < bufBlocks; blk++) {
+          if(__CryptoAESOpMode == CRYPTO_AES_CBC_MODE) {
+               CryptoAESBlock_t inputBlock;
+               if(blk == 0) {
+                    memcpy(inputBlock, &Plaintext[0], CRYPTO_AES_BLOCK_SIZE);
+                    CryptoMemoryXOR(IV, inputBlock, CRYPTO_AES_BLOCK_SIZE);
+               }
+               else {
+                    memcpy(inputBlock, &Ciphertext[(blk - 1) * CRYPTO_AES_BLOCK_SIZE], CRYPTO_AES_BLOCK_SIZE);
+                    CryptoMemoryXOR(&Plaintext[blk * CRYPTO_AES_BLOCK_SIZE], inputBlock, CRYPTO_AES_BLOCK_SIZE);
+               }
+               CryptoAESEncryptBlock(inputBlock, Ciphertext + blk * CRYPTO_AES_BLOCK_SIZE, Key, true);
+          }
+          else {
+               CryptoAESEncryptBlock(Plaintext + blk * CRYPTO_AES_BLOCK_SIZE,
+                                     Ciphertext + blk * CRYPTO_AES_BLOCK_SIZE, Key, true);
+          }
+     }
+     return 0;
+}
+
+uint8_t CryptoAESDecryptBuffer(uint16_t Count, uint8_t *Plaintext, uint8_t *Ciphertext, 
+                               const uint8_t *IV, const uint8_t *Key) {
+     if((Count % CRYPTO_AES_BLOCK_SIZE) != 0) {
+          return 0xBE;
+     }
+     else if(IV == NULL) {
+          memset(__CryptoAES_IVData, 0x00, CRYPTO_AES_BLOCK_SIZE);     
+          IV = &__CryptoAES_IVData[0];
+     }
+     size_t bufBlocks = (Count + CRYPTO_AES_BLOCK_SIZE - 1) / CRYPTO_AES_BLOCK_SIZE;
+     for(int blk = 0; blk < bufBlocks; blk++) {
+          if(__CryptoAESOpMode == CRYPTO_AES_CBC_MODE) {
+               CryptoAESBlock_t inputBlock;
+               CryptoAESDecryptBlock(inputBlock, Ciphertext + blk * CRYPTO_AES_BLOCK_SIZE, Key);
+               if(blk == 0) {
+                    memcpy(Plaintext + blk * CRYPTO_AES_BLOCK_SIZE, inputBlock, CRYPTO_AES_BLOCK_SIZE);
+                    CryptoMemoryXOR(IV, Plaintext + blk * CRYPTO_AES_BLOCK_SIZE, CRYPTO_AES_BLOCK_SIZE);
+               }
+               else {
+                    memcpy(Plaintext + blk * CRYPTO_AES_BLOCK_SIZE, inputBlock, CRYPTO_AES_BLOCK_SIZE);
+                    CryptoMemoryXOR(&Ciphertext[(blk - 1) * CRYPTO_AES_BLOCK_SIZE], 
+                                    Plaintext + blk * CRYPTO_AES_BLOCK_SIZE, CRYPTO_AES_BLOCK_SIZE);
+               }
+          }
+          else {
+               CryptoAESDecryptBlock(Plaintext + blk * CRYPTO_AES_BLOCK_SIZE,
+                                     Ciphertext + blk * CRYPTO_AES_BLOCK_SIZE, Key);
+          }
+     }
+     return 0;
+}
+
+// This routine performs the CBC "send" mode chaining: C = E(P ^ IV); IV = C
+void CryptoAES_CBCSend(uint16_t Count, void* Plaintext, void* Ciphertext,
+                       uint8_t *IV, uint8_t *Key,
+                       CryptoAES_CBCSpec_t CryptoSpec) {
+    uint16_t numBlocks = CRYPTO_BYTES_TO_BLOCKS(Count, CryptoSpec.blockSize);
+    uint16_t blockIndex = 0;
+    uint8_t *ptBuf = (uint8_t *) Plaintext, *ctBuf = (uint8_t *) Ciphertext;
+    uint8_t tempBlock[CryptoSpec.blockSize], ivBlock[CryptoSpec.blockSize];
+    bool lastBlockPadding = false;
+    if(numBlocks * CryptoSpec.blockSize > Count) {
+         lastBlockPadding = true;
+    }
+    while(blockIndex < numBlocks) {
+        if(blockIndex + 1 == numBlocks && lastBlockPadding) {
+            return;
+        }
+        memcpy(tempBlock, ptBuf + blockIndex * CryptoSpec.blockSize, CryptoSpec.blockSize);
+        memcpy(ivBlock, IV, CryptoSpec.blockSize);
+        CryptoMemoryXOR(ivBlock, tempBlock, CryptoSpec.blockSize);
+        CryptoSpec.cryptFunc(ivBlock, tempBlock, Key);
+        memcpy(IV + blockIndex * CryptoSpec.blockSize, tempBlock, CryptoSpec.blockSize);
+        memcpy(ctBuf + blockIndex * CryptoSpec.blockSize, tempBlock, CryptoSpec.blockSize);
+        blockIndex++;
+    }
+}
+
+// This routine performs the CBC "receive" mode chaining: C = E(P) ^ IV; IV = P
+void CryptoAES_CBCRecv(uint16_t Count, void* Plaintext, void* Ciphertext,
+                       uint8_t *IV, uint8_t *Key,
+                       CryptoAES_CBCSpec_t CryptoSpec) {
+    uint16_t numBlocks = CRYPTO_BYTES_TO_BLOCKS(Count, CryptoSpec.blockSize);
+    uint16_t blockIndex = 0;
+    uint8_t *ptBuf = (uint8_t *) Plaintext, *ctBuf = (uint8_t *) Ciphertext;
+    uint8_t tempBlock[CryptoSpec.blockSize], ivBlock[CryptoSpec.blockSize];
+    bool lastBlockPadding = false;
+    if(numBlocks * CryptoSpec.blockSize > Count) {
+         lastBlockPadding = true;
+    }
+    while(blockIndex < numBlocks) {
+        if(blockIndex + 1 == numBlocks && lastBlockPadding) {
+             return;
+        }
+        memcpy(ivBlock, ptBuf + blockIndex * CryptoSpec.blockSize, CryptoSpec.blockSize);
+        CryptoSpec.cryptFunc(ivBlock, tempBlock, Key);
+        memcpy(ivBlock, IV, CryptoSpec.blockSize);
+        CryptoMemoryXOR(ivBlock, tempBlock, CryptoSpec.blockSize);
+        memcpy(IV, ptBuf + blockIndex * CryptoSpec.blockSize, CryptoSpec.blockSize);
+        memcpy(ctBuf + blockIndex * CryptoSpec.blockSize, ivBlock, CryptoSpec.blockSize);
+        blockIndex++;
+    }
+}
+
+void CryptoAESEncrypt_CBCSend(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText,
+                              uint8_t *Key, uint8_t *IV) {
+     CryptoAES_CBCSpec_t CryptoSpec = { 
+         .cryptFunc   = &CryptoAESEncryptBlock,
+         .blockSize   = CRYPTO_AES_BLOCK_SIZE
+     };  
+     CryptoAES_CBCSend(Count, PlainText, CipherText, IV, Key, CryptoSpec);
+}
+
+void CryptoAESDecrypt_CBCSend(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText,
+                              uint8_t *Key, uint8_t *IV) {
+     CryptoAES_CBCSpec_t CryptoSpec = { 
+         .cryptFunc   = &CryptoAESDecryptBlock,
+         .blockSize   = CRYPTO_AES_BLOCK_SIZE
+     };  
+     CryptoAES_CBCSend(Count, PlainText, CipherText, IV, Key, CryptoSpec);
+}
+
+void CryptoAESEncrypt_CBCReceive(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText,
+                                 uint8_t *Key, uint8_t *IV) {
+     CryptoAES_CBCSpec_t CryptoSpec = { 
+         .cryptFunc   = &CryptoAESEncryptBlock,
+         .blockSize   = CRYPTO_AES_BLOCK_SIZE
+     };  
+     CryptoAES_CBCRecv(Count, PlainText, CipherText, IV, Key, CryptoSpec);
+}
+
+void CryptoAESDecrypt_CBCReceive(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText,
+                                 uint8_t *Key, uint8_t *IV) {
+     CryptoAES_CBCSpec_t CryptoSpec = { 
+         .cryptFunc   = &CryptoAESDecryptBlock,
+         .blockSize   = CRYPTO_AES_BLOCK_SIZE
+     };  
+     CryptoAES_CBCRecv(Count, PlainText, CipherText, IV, Key, CryptoSpec);
+}

--- a/Firmware/Chameleon-Mini/Application/CryptoAES128.h
+++ b/Firmware/Chameleon-Mini/Application/CryptoAES128.h
@@ -1,0 +1,183 @@
+/* CryptoAES128.h : Adds support for XMega HW accelerated 128-bit AES encryption 
+ *                  in ECB and CBC modes. 
+ *                  Based in part on the the source code for Microchip's ASF library 
+ *                  available at https://github.com/avrxml/asf (see license below). 
+ * Author: Maxie D. Schmidt (@maxieds) 
+ */
+
+/*****************************************************************************
+ * Copyright (c) 2014-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *****************************************************************************/
+
+#ifndef __CRYPTO_AES128_HW_H__
+#define __CRYPTO_AES128_HW_H__
+
+#include <avr/io.h>
+
+/* AES Processing mode */
+#define CRYPTO_AES_PMODE_DECIPHER          0     // decipher
+#define CRYPTO_AES_PMODE_ENCIPHER          1     // cipher
+
+/* AES Start mode */
+#define CRYPTO_AES_START_MODE_MANUAL       0     // Manual mode
+#define CRYPTO_AES_START_MODE_AUTO         1     // Auto mode
+#define CRYPTO_AES_START_MODE_DMA          2     // DMA mode
+
+/* AES Cryptographic key size */
+#define CRYPTO_AES_KEY_SIZE_128            0     // 128-bit
+#define CRYPTO_AES_KEY_SIZE_192            1     // 192-bit
+#define CRYPTO_AES_KEY_SIZE_256            2     // 256-bit
+
+/* AES Operation cipher mode */
+#define CRYPTO_AES_ECB_MODE                0     // Electronic Code Book mode
+#define CRYPTO_AES_CBC_MODE                1     // Cipher Block Chaining mode
+#define CRYPTO_AES_OFB_MODE                2     // Output FeedBack mode
+#define CRYPTO_AES_CFB_MODE                3     // Cipher FeedBack mode
+#define CRYPTO_AES_CTR_MODE                4     // Counter mode
+
+/* AES URAD Type */
+#define CRYPTO_AES_URAT_INPUTWRITE_DMA     0     // Input Data Register written during the data processing in DMA mode
+#define CRYPTO_AES_URAT_OUTPUTREAD_PROCESS 1     // Output Data Register read during the data processing
+#define CRYPTO_AES_URAT_MRWRITE_PROCESS    2     // Mode Register written during the data processing
+#define CRYPTO_AES_URAT_OUTPUTREAD_SUBKEY  3     // Output Data Register read during the sub-keys generation
+#define CRYPTO_AES_URAT_MRWRITE_SUBKEY     4     // Mode Register written during the sub-keys generation
+#define CRYPTO_AES_URAT_READ_WRITEONLY     5     // Write-only register read access
+
+/* Define types for the AES-128 specific implementation: */
+#define CRYPTO_AES_KEY_SIZE                16
+typedef uint8_t CryptoAESKey_t[CRYPTO_AES_KEY_SIZE];
+
+#define CRYPTO_AES_BLOCK_SIZE	             16
+typedef uint8_t CryptoAESBlock_t[CRYPTO_AES_BLOCK_SIZE];
+
+#define CryptoAESBytesToBlocks(byteCount) \
+     ((byteCount + CRYPTO_AES_BLOCK_SIZE - 1) / CRYPTO_AES_BLOCK_SIZE)
+
+typedef enum aes_dec {
+	AES_ENCRYPT,                     
+	AES_DECRYPT = AES_DECRYPT_bm,    
+} CryptoAESDec_t;
+
+/* AES Auto Start Trigger settings */
+typedef enum aes_auto {
+	AES_MANUAL,                      // manual start mode.
+	AES_AUTO = AES_AUTO_bm,          // auto start mode.
+} CryptoAESAuto_t;
+
+/* AES State XOR Load Enable settings */
+typedef enum aes_xor {
+	AES_XOR_OFF,                    // state direct load.
+	AES_XOR_ON = AES_XOR_bm,        // state XOR load.
+} CryptoAESXor_t;
+
+/* AES Interrupt Enable / Level settings */
+typedef enum aes_intlvl {
+	AES_INTLVL_OFF = AES_INTLVL_OFF_gc,  // Interrupt Disabled
+	AES_INTLVL_LO  = AES_INTLVL_LO_gc,   // Low Level
+	AES_INTLVL_MED = AES_INTLVL_MED_gc,  // Medium Level
+	AES_INTLVL_HI  = AES_INTLVL_HI_gc,   // High Level
+} CryptoAESIntlvl_t;
+
+/* AES interrupt callback function pointer. */
+typedef void (*aes_callback_t)(void);
+
+typedef struct {
+    CryptoAESDec_t   ProcessingMode; 
+    uint8_t          ProcessingDelay;            // [0,15]
+    CryptoAESAuto_t  StartMode;
+    unsigned char    OpMode;                     // 0 = ECB, 1 = CBC, 2 = OFB, 3 = CFB, 4 = CTR
+    CryptoAESXor_t   XorMode;
+} CryptoAESConfig_t;
+
+typedef struct {
+    unsigned char   datrdy;                      // ENABLE/DISABLE; Data ready interrupt
+    unsigned char   urad;                        // ENABLE/DISABLE; Unspecified Register Access Detection
+} CryptoAES_ISRConfig_t; 
+
+/* AES encryption complete. */
+#define AES_ENCRYPTION_COMPLETE  (1UL << 0)
+
+/* AES GF multiplication complete. */
+#define AES_GF_MULTI_COMPLETE    (1UL << 1)
+
+void aes_start(void);
+void aes_software_reset(void);
+bool aes_is_busy(void);
+bool aes_is_error(void);
+void aes_clear_interrupt_flag(void);
+void aes_clear_error_flag(void);
+void aes_configure(CryptoAESDec_t op_mode, CryptoAESAuto_t auto_start, CryptoAESXor_t xor_mode);
+void aes_configure_encrypt(CryptoAESAuto_t auto_start, CryptoAESXor_t xor_mode);
+void aes_configure_decrypt(CryptoAESAuto_t auto_start, CryptoAESXor_t xor_mode);
+void aes_set_key(uint8_t *key_in);
+void aes_get_key(uint8_t *key_out);
+void aes_write_inputdata(uint8_t *data_in);
+void aes_read_outputdata(uint8_t *data_out);
+void aes_isr_configure(CryptoAESIntlvl_t intlvl);
+void aes_set_callback(const aes_callback_t callback);
+
+void CryptoAESGetConfigDefaults(CryptoAESConfig_t *ctx);
+void CryptoAESInitContext(CryptoAESConfig_t *ctx);
+uint16_t CryptoAESGetPaddedBufferSize(uint16_t bufSize);
+
+void CryptoAESEncryptBlock(uint8_t *Plaintext, uint8_t *Ciphertext, const uint8_t *Key, bool);
+void CryptoAESDecryptBlock(uint8_t *Plaintext, uint8_t *Ciphertext, const uint8_t *Key);
+uint8_t CryptoAESEncryptBuffer(uint16_t Count, uint8_t *Plaintext, uint8_t *Ciphertext, 
+                               const uint8_t *IV, const uint8_t *Key);
+uint8_t CryptoAESDecryptBuffer(uint16_t Count, uint8_t *Plaintext, uint8_t *Ciphertext, 
+                               const uint8_t *IV, const uint8_t *Key);
+
+typedef uint8_t (*CryptoAESFuncType)(uint8_t*, uint8_t*, uint8_t*);
+typedef struct {
+    CryptoAESFuncType  cryptFunc;
+    uint16_t           blockSize;
+} CryptoAES_CBCSpec_t;
+
+void CryptoAES_CBCSend(uint16_t Count, void* Plaintext, void* Ciphertext, 
+                       uint8_t *IV, uint8_t *Key, 
+                       CryptoAES_CBCSpec_t CryptoSpec);
+void CryptoAES_CBCRecv(uint16_t Count, void* Plaintext, void* Ciphertext, 
+                       uint8_t *IV, uint8_t *Key, 
+                       CryptoAES_CBCSpec_t CryptoSpec);
+
+void CryptoAESEncrypt_CBCSend(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText, 
+                              uint8_t *Key, uint8_t *IV); 
+void CryptoAESDecrypt_CBCSend(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText, 
+                              uint8_t *Key, uint8_t *IV);
+void CryptoAESEncrypt_CBCReceive(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText, 
+                                 uint8_t *Key, uint8_t *IV);
+void CryptoAESDecrypt_CBCReceive(uint16_t Count, uint8_t *PlainText, uint8_t *CipherText, 
+                                 uint8_t *Key, uint8_t *IV);
+
+/* Crypto utility functions: */
+#define CRYPTO_BYTES_TO_BLOCKS(numBytes, blockSize) \
+     ( ((numBytes) + (blockSize) - 1) / (blockSize) )
+
+#define CryptoMemoryXOR(inputBuf, destBuf, bufSize) ({ \
+     uint8_t *in = (uint8_t *) inputBuf;               \
+     uint8_t *out = (uint8_t *) destBuf;               \
+     uint16_t count = (uint16_t) bufSize;              \
+     while(count-- > 0) {                              \
+          *(out++) ^= *(in++);                         \
+     }                                                 \
+     })
+
+#endif

--- a/Firmware/Chameleon-Mini/Application/CryptoTDEA-HWAccelerated.S
+++ b/Firmware/Chameleon-Mini/Application/CryptoTDEA-HWAccelerated.S
@@ -1,0 +1,872 @@
+;
+; DEA related code is kept in this file.
+; All data is handled big-endian style (MSByte first) in memory.
+;
+
+.section .text
+
+; This routine loads the key and performs 16 rounds of DEA.
+;
+; Input:
+;     R31:R30 - A pointer to the 8-byte key (with parity bits), MSB first.
+;     R7:R0   - 8-byte input data block, LSB in R0.
+;     SREG:H  - Set to decipher, clear to encipher.
+;
+; Returns:
+;     R7:R0   - Result of en/deciphering, LSB in R0
+_LoadKeyAndRunDEA:
+    ld      r15, Z+
+    ld      r14, Z+
+    ld      r13, Z+
+    ld      r12, Z+
+    ld      r11, Z+
+    ld      r10, Z+
+    ld      r9,  Z+
+    ld      r8,  Z+
+    des     0
+    des     1
+    des     2
+    des     3
+    des     4
+    des     5
+    des     6
+    des     7
+    des     8
+    des     9
+    des     10
+    des     11
+    des     12
+    des     13
+    des     14
+    des     15
+    ret
+
+;
+; Triple DEA subroutines
+;
+
+; This routine performs Triple DEA encryption (E-D-E) using keying option 1: K1, K2, K3.
+;
+; Input:
+;     R17:R16 - Key block pointer.
+;     R7:R0   - Input data, LSB in R0
+;
+; Returns:
+;     R7:R0   - Result of enciphering, LSB in R0
+_Encrypt3KTDEA:
+    ; Reload Z with the key block pointer
+    movw    r30, r16
+    ; Encipher
+    clh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Z now points to K2
+    ; Decipher
+    seh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Z now points to K3
+    ; Encipher
+    clh
+    rjmp    _LoadKeyAndRunDEA
+
+; This routine performs Triple DEA encryption (E-D-E) using keying option 2: K1, K2, K1.
+;
+; Input:
+;     R17:R16 - Key block pointer.
+;     R7:R0   - Input data, LSB in R0
+;
+; Returns:
+;     R7:R0   - Result of enciphering, LSB in R0
+_Encrypt2KTDEA:
+    ; Reload Z with the key block pointer
+    movw    r30, r16
+    ; Encipher
+    clh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Z now points to K2
+    ; Decipher
+    seh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Reload Z with the key block pointer
+    movw    r30, r16
+    ; Encipher
+    clh
+    rjmp    _LoadKeyAndRunDEA
+
+
+
+; Input:
+;     R17:R16 - Key block pointer.
+;     R7:R0   - Input data, LSB in R0
+;
+; Returns:
+;     R7:R0   - Result of enciphering, LSB in R0
+_EncryptDEA:
+	; Reload Z with the key block pointer
+	movw    r30, r16
+    ; Encipher
+    clh
+    rjmp    _LoadKeyAndRunDEA
+
+
+; Input:
+;     R17:R16 - Key block pointer.
+;     R7:R0   - Input data, LSB in R0
+;
+; Returns:
+;     R7:R0   - Result of enciphering, LSB in R0
+_DecryptDEA:
+	; Reload Z with the key block pointer
+	movw    r30, r16
+    ; Encipher
+    seh
+    rjmp    _LoadKeyAndRunDEA
+
+
+
+; This routine performs Triple DEA decryption (D-E-D) using keying option 1: K1, K2, K3.
+;
+; Input:
+;     R17:R16 - Key block pointer.
+;     R7:R0   - Input data, LSB in R0
+;
+; Returns:
+;     R7:R0   - Result of enciphering, LSB in R0
+_Decrypt3KTDEA:
+    ; Reload Z with the key block pointer and adjust to point to K3
+    movw    r30, r16
+    adiw    r30, 16
+    ; Decipher
+    seh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Reload Z with the key block pointer and adjust to point to K2
+    movw    r30, r16
+    adiw    r30, 8
+    ; Encipher
+    clh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Reload Z with the key block pointer
+    movw    r30, r16
+    ; Decipher
+    seh
+    rjmp    _LoadKeyAndRunDEA
+
+; This routine performs Triple DEA decryption (D-E-D) using keying option 2: K1, K2, K1.
+;
+; Input:
+;     R17:R16 - Key block pointer.
+;     R7:R0   - Input data, LSB in R0
+;
+; Returns:
+;     R7:R0   - Result of enciphering, LSB in R0
+_Decrypt2KTDEA:
+    ; Reload Z with the key block pointer
+    movw    r30, r16
+    ; Decipher
+    seh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Z now points to K2
+    ; Encipher
+    clh
+    rcall   _LoadKeyAndRunDEA
+
+    ; Reload Z with the key block pointer
+    movw    r30, r16
+    ; Decipher
+    seh
+    rjmp    _LoadKeyAndRunDEA
+
+;
+; Common prologue and epilogue code
+;
+
+_CommonEpilogue:
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r12
+    pop     r11
+    pop     r10
+    pop     r9
+    pop     r8
+    pop     r7
+    pop     r6
+    pop     r5
+    pop     r4
+    pop     r3
+    pop     r2
+    eor     r1, r1
+    ret
+
+;
+; Triple DEA ECB Routines
+;
+
+; Input:
+;     R25:R24 - Pointer to plaintext input buffer
+;     R23:R22 - Pointer to ciphertext output buffer
+;     R21:R20 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoEncryptDEA
+CryptoEncryptDEA:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r16
+    push    r17
+
+    ; Load the plaintext pointer to Z and fetch data
+    movw    r30, r24
+    ld      r7, Z+
+    ld      r6, Z+
+    ld      r5, Z+
+    ld      r4, Z+
+    ld      r3, Z+
+    ld      r2, Z+
+    ld      r1, Z+
+    ld      r0, Z+
+    ; Encrypt
+    movw    r16, r20 
+    rcall   _EncryptDEA
+    ; Store the ciphertext
+    movw    r30, r22 
+    st      Z+, r7
+    st      Z+, r6
+    st      Z+, r5
+    st      Z+, r4
+    st      Z+, r3
+    st      Z+, r2
+    st      Z+, r1
+    st      Z+, r0
+
+    ; Restore clobbered regs
+    pop     r17 
+    pop     r16 
+    ; Reuse epilogue code
+    rjmp    _CommonEpilogue
+
+; Input:
+;     R25:R24 - Pointer to plaintext input buffer
+;     R23:R22 - Pointer to ciphertext output buffer
+;     R21:R20 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoDecryptDEA
+CryptoDecryptDEA:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r16
+    push    r17
+
+    ; Load the plaintext pointer to Z and fetch data
+    movw    r30, r24
+    ld      r7, Z+
+    ld      r6, Z+
+    ld      r5, Z+
+    ld      r4, Z+
+    ld      r3, Z+
+    ld      r2, Z+
+    ld      r1, Z+
+    ld      r0, Z+
+    ; Encrypt
+    movw    r16, r20
+    rcall   _DecryptDEA
+    ; Store the ciphertext
+    movw    r30, r22
+    st      Z+, r7
+    st      Z+, r6
+    st      Z+, r5
+    st      Z+, r4
+    st      Z+, r3
+    st      Z+, r2
+    st      Z+, r1
+    st      Z+, r0
+
+    ; Restore clobbered regs
+    pop     r17
+    pop     r16
+    ; Reuse epilogue code
+    rjmp    _CommonEpilogue
+
+; This routine performs Triple DEA encryption using keying option 2: K1, K2, K1.
+;
+; Input:
+;     R25:R24 - Pointer to plaintext output buffer
+;     R23:R22 - Pointer to ciphertext input buffer
+;     R21:R20 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoDecrypt2KTDEA
+CryptoDecrypt2KTDEA:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r16
+    push    r17
+
+    ; Load the plaintext pointer to Z and fetch data
+    movw    r30, r22
+    ld      r7, Z+
+    ld      r6, Z+
+    ld      r5, Z+
+    ld      r4, Z+
+    ld      r3, Z+
+    ld      r2, Z+
+    ld      r1, Z+
+    ld      r0, Z+
+    ; Encrypt
+    movw    r16, r20
+    rcall   _Decrypt2KTDEA
+    ; Store the ciphertext
+    movw    r30, r24
+    st      Z+, r7
+    st      Z+, r6
+    st      Z+, r5
+    st      Z+, r4
+    st      Z+, r3
+    st      Z+, r2
+    st      Z+, r1
+    st      Z+, r0
+
+    ; Restore clobbered regs
+    pop     r17
+    pop     r16
+    ; Reuse epilogue code
+    rjmp    _CommonEpilogue
+
+.global CryptoDecrypt3KTDEA
+CryptoDecrypt3KTDEA:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r16
+    push    r17
+
+    ; Load the plaintext pointer to Z and fetch data
+    movw    r30, r22
+    ld      r7, Z+
+    ld      r6, Z+
+    ld      r5, Z+
+    ld      r4, Z+
+    ld      r3, Z+
+    ld      r2, Z+
+    ld      r1, Z+
+    ld      r0, Z+
+    ; Encrypt
+    movw    r16, r20
+    rcall   _Decrypt3KTDEA
+    ; Store the ciphertext
+    movw    r30, r24
+    st      Z+, r7
+    st      Z+, r6
+    st      Z+, r5
+    st      Z+, r4
+    st      Z+, r3
+    st      Z+, r2
+    st      Z+, r1
+    st      Z+, r0
+
+    ; Restore clobbered regs
+    pop     r17
+    pop     r16
+    ; Reuse epilogue code
+    rjmp    _CommonEpilogue
+
+; This routine performs Triple DEA encryption using keying option 2: K1, K2, K1.
+;
+; Input:
+;     R25:R24 - Pointer to plaintext input buffer
+;     R23:R22 - Pointer to ciphertext output buffer
+;     R21:R20 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoEncrypt2KTDEA
+CryptoEncrypt2KTDEA:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r16
+    push    r17
+
+    ; Load the plaintext pointer to Z and fetch data
+    movw    r30, r24
+    ld      r7, Z+
+    ld      r6, Z+
+    ld      r5, Z+
+    ld      r4, Z+
+    ld      r3, Z+
+    ld      r2, Z+
+    ld      r1, Z+
+    ld      r0, Z+
+    ; Encrypt
+    movw    r16, r20
+    rcall   _Encrypt2KTDEA
+    ; Store the ciphertext
+    movw    r30, r22
+    st      Z+, r7
+    st      Z+, r6
+    st      Z+, r5
+    st      Z+, r4
+    st      Z+, r3
+    st      Z+, r2
+    st      Z+, r1
+    st      Z+, r0
+
+    ; Restore clobbered regs
+    pop     r17
+    pop     r16
+    ; Reuse epilogue code
+    rjmp    _CommonEpilogue
+
+.global CryptoEncrypt3KTDEA
+CryptoEncrypt3KTDEA:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r16
+    push    r17
+
+    ; Load the plaintext pointer to Z and fetch data
+    movw    r30, r24
+    ld      r7, Z+
+    ld      r6, Z+
+    ld      r5, Z+
+    ld      r4, Z+
+    ld      r3, Z+
+    ld      r2, Z+
+    ld      r1, Z+
+    ld      r0, Z+
+    ; Encrypt
+    movw    r16, r20
+    rcall   _Encrypt3KTDEA
+    ; Store the ciphertext
+    movw    r30, r22
+    st      Z+, r7
+    st      Z+, r6
+    st      Z+, r5
+    st      Z+, r4
+    st      Z+, r3
+    st      Z+, r2
+    st      Z+, r1
+    st      Z+, r0
+
+    ; Restore clobbered regs
+    pop     r17
+    pop     r16
+    ; Reuse epilogue code
+    rjmp    _CommonEpilogue
+
+;
+; Triple DEA CBC Routines
+;
+
+; This routine performs the CBC "send" mode chaining: C = E(P ^ IV); IV = C
+;
+; Input:
+;     R31:R30 - Cryptographic primitive pointer
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+;
+_DEACBCSend:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r28
+    push    r29
+
+    ; Load the plaintext pointer to Y
+    movw    r28, r22
+    ; Load the ciphertext pointer to X
+    movw    r26, r20
+    ; Store the crypto primitive pointer in r23:r22
+    movw    r22, r30
+
+    ; Load the IV pointer to Z
+    movw    r30, r18
+    ; Load the IV
+    ld      r7, Z+
+    ld      r6, Z+
+    ld      r5, Z+
+    ld      r4, Z+
+    ld      r3, Z+
+    ld      r2, Z+
+    ld      r1, Z+
+    ld      r0, Z+
+
+1:
+    ; Load the plaintext block
+    ld      r15, Y+
+    ld      r14, Y+
+    ld      r13, Y+
+    ld      r12, Y+
+    ld      r11, Y+
+    ld      r10, Y+
+    ld      r9, Y+
+    ld      r8, Y+
+    ; XOR the plaintext with the IV
+    eor     r7, r15
+    eor     r6, r14
+    eor     r5, r13
+    eor     r4, r12
+    eor     r3, r11
+    eor     r2, r10
+    eor     r1, r9
+    eor     r0, r8
+
+    ; Call the primitive
+    movw    r30, r22
+    icall
+
+    ; Store the ciphertext
+    ; It will be reused as the IV for the next block, if any
+    st      X+, r7
+    st      X+, r6
+    st      X+, r5
+    st      X+, r4
+    st      X+, r3
+    st      X+, r2
+    st      X+, r1
+    st      X+, r0
+
+    ; Decrement the counter, repeat if more blocks.
+    sbiw    r24, 1
+    brne    1b
+
+    ; Load the IV pointer to X
+    movw    r26, r18
+    ; Store the updated IV
+    st      X+, r7
+    st      X+, r6
+    st      X+, r5
+    st      X+, r4
+    st      X+, r3
+    st      X+, r2
+    st      X+, r1
+    st      X+, r0
+
+    ; Restore clobbered regs
+    pop     r29
+    pop     r28
+    rjmp    _CommonEpilogue
+
+; This routine performs the CBC "receive" mode chaining: C = E(P) ^ IV; IV = P
+;
+; Input:
+;     R31:R30 - Cryptographic primitive pointer
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+;
+_DEACBCReceive:
+    ; Preserve the clobbered regs
+    push    r2
+    push    r3
+    push    r4
+    push    r5
+    push    r6
+    push    r7
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    r28
+    push    r29
+
+    ; Load the plaintext pointer to Y
+    movw    r28, r22
+    ; Load the ciphertext pointer to X
+    movw    r26, r20
+    ; Store the crypto primitive pointer in r23:r22
+    movw    r22, r30
+
+1:
+    ; Load the plaintext block
+    ldd     r7, Y+0
+    ldd     r6, Y+1
+    ldd     r5, Y+2
+    ldd     r4, Y+3
+    ldd     r3, Y+4
+    ldd     r2, Y+5
+    ldd     r1, Y+6
+    ldd     r0, Y+7
+
+    ; Call the primitive
+    movw    r30, r22
+    icall
+    
+    ; Load the IV block
+    movw    r30, r18
+    ld      r15, Z+
+    ld      r14, Z+
+    ld      r13, Z+
+    ld      r12, Z+
+    ld      r11, Z+
+    ld      r10, Z+
+    ld      r9, Z+
+    ld      r8, Z+
+    ; XOR the ciphertext with the IV
+    eor     r7, r15
+    eor     r6, r14
+    eor     r5, r13
+    eor     r4, r12
+    eor     r3, r11
+    eor     r2, r10
+    eor     r1, r9
+    eor     r0, r8
+    ; Reload the plaintext block
+    ld      r15, Y+
+    ld      r14, Y+
+    ld      r13, Y+
+    ld      r12, Y+
+    ld      r11, Y+
+    ld      r10, Y+
+    ld      r9, Y+
+    ld      r8, Y+
+    ; Store the new IV before it gets potentially overwritten
+    movw    r30, r18
+    st      Z+, r15
+    st      Z+, r14
+    st      Z+, r13
+    st      Z+, r12
+    st      Z+, r11
+    st      Z+, r10
+    st      Z+, r9
+    st      Z+, r8
+    ; Store the ciphertext
+    st      X+, r7
+    st      X+, r6
+    st      X+, r5
+    st      X+, r4
+    st      X+, r3
+    st      X+, r2
+    st      X+, r1
+    st      X+, r0
+
+    ; Decrement the counter, repeat if more blocks.
+    sbiw    r24, 1
+    brne    1b
+
+    ; Restore clobbered regs
+    pop     r29
+    pop     r28
+    rjmp    _CommonEpilogue
+
+
+; This routine performs Triple DEA encryption in CBC mode using keying option 2: K1, K2, K1.
+; The CBC is operated in the "send" mode: C = E(P ^ IV); IV = C
+;
+; Input:
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoEncrypt2KTDEA_CBCSend
+CryptoEncrypt2KTDEA_CBCSend:
+    ldi     r31, pm_hi8(_Encrypt2KTDEA)
+    ldi     r30, pm_lo8(_Encrypt2KTDEA)
+    rjmp    _DEACBCSend
+
+; This routine performs Triple DEA encryption in CBC mode using keying option 2: K1, K2, K1.
+; The CBC is operated in the "receive" mode: C = E(P) ^ IV; IV = P
+;
+; Input:
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoEncrypt2KTDEA_CBCReceive
+CryptoEncrypt2KTDEA_CBCReceive:
+    ldi     r31, pm_hi8(_Encrypt2KTDEA)
+    ldi     r30, pm_lo8(_Encrypt2KTDEA)
+    rjmp    _DEACBCReceive
+
+; This routine performs Triple DEA decryption in CBC mode using keying option 2: K1, K2, K1.
+; The CBC is operated in the "send" mode: C = E(P ^ IV); IV = C
+;
+; Input:
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoDecrypt2KTDEA_CBCSend
+CryptoDecrypt2KTDEA_CBCSend:
+    ldi     r31, pm_hi8(_Decrypt2KTDEA)
+    ldi     r30, pm_lo8(_Decrypt2KTDEA)
+    rjmp    _DEACBCSend
+
+; This routine performs Triple DEA decryption in CBC mode using keying option 2: K1, K2, K1.
+; The CBC is operated in the "receive" mode: C = E(P) ^ IV; IV = P
+;
+; Input:
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoDecrypt2KTDEA_CBCReceive
+CryptoDecrypt2KTDEA_CBCReceive:
+    ldi     r31, pm_hi8(_Decrypt2KTDEA)
+    ldi     r30, pm_lo8(_Decrypt2KTDEA)
+    rjmp    _DEACBCReceive
+
+; This routine performs Triple DEA encryption in CBC mode using keying option 1: K1, K2, K3.
+; The CBC is operated in the "send" mode: C = E(P ^ IV); IV = C
+;
+; Input:
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoEncrypt3KTDEA_CBCSend
+CryptoEncrypt3KTDEA_CBCSend:
+    ldi     r31, pm_hi8(_Encrypt3KTDEA)
+    ldi     r30, pm_lo8(_Encrypt3KTDEA)
+    rjmp    _DEACBCSend
+
+; This routine performs Triple DEA decryption in CBC mode using keying option 1: K1, K2, K3.
+; The CBC is operated in the "receive" mode: C = E(P) ^ IV; IV = P
+;
+; Input:
+;     R25:R24 - Count of blocks.
+;     R23:R22 - Pointer to plaintext input buffer
+;     R21:R20 - Pointer to ciphertext output buffer
+;     R19:R18 - IV block pointer.
+;     R17:R16 - Key block pointer.
+;
+; Returns:
+;     Nothing.
+.global CryptoEncrypt3KTDEA_CBCReceive
+CryptoEncrypt3KTDEA_CBCReceive:
+    ldi     r31, pm_hi8(_Decrypt3KTDEA)
+    ldi     r30, pm_lo8(_Decrypt3KTDEA)
+    rjmp    _DEACBCReceive

--- a/Firmware/Chameleon-Mini/Application/CryptoTDEA.c
+++ b/Firmware/Chameleon-Mini/Application/CryptoTDEA.c
@@ -1,0 +1,74 @@
+/* CryptoTDEA.c : Extended support for the DES encryption schemes.
+ * Author: Maxie D. Schmidt (@maxieds)
+ */
+
+#include "../Common.h"
+#include "CryptoTDEA.h"
+
+//__asm__(
+//    STRINGIFY(#include "CryptoTDEA.S")
+//);
+
+void EncryptDESBuffer(uint16_t Count, const void* Plaintext, void* Ciphertext, const uint8_t* Keys) {
+     CryptoTDEA_CBCSpec CryptoSpec = {
+         .cryptFunc   = &CryptoEncryptDEA,
+         .blockSize   = CRYPTO_DES_BLOCK_SIZE
+     };
+     uint16_t numBlocks = (Count + CryptoSpec.blockSize - 1) / CryptoSpec.blockSize;
+     uint16_t blockIndex = 0;
+     uint8_t *ptBuf = (uint8_t *) Plaintext, *ctBuf = (uint8_t *) Ciphertext;
+     while(blockIndex < numBlocks) {
+        CryptoSpec.cryptFunc(ptBuf, ctBuf, Keys);
+        ptBuf += CryptoSpec.blockSize;
+        ctBuf += CryptoSpec.blockSize;
+        blockIndex++;
+    }
+}
+
+void DecryptDESBuffer(uint16_t Count, void* Plaintext, const void* Ciphertext, const uint8_t* Keys) {
+     CryptoTDEA_CBCSpec CryptoSpec = {
+         .cryptFunc   = &CryptoDecryptDEA,
+         .blockSize   = CRYPTO_DES_BLOCK_SIZE
+     };
+     uint16_t numBlocks = (Count + CryptoSpec.blockSize - 1) / CryptoSpec.blockSize;
+     uint16_t blockIndex = 0;
+     uint8_t *ptBuf = (uint8_t *) Plaintext, *ctBuf = (uint8_t *) Ciphertext;
+     while(blockIndex < numBlocks) {
+        CryptoSpec.cryptFunc(ptBuf, ctBuf, Keys);
+        ptBuf += CryptoSpec.blockSize;
+        ctBuf += CryptoSpec.blockSize;
+        blockIndex++;
+    }
+}
+
+void Encrypt3DESBuffer(uint16_t Count, const void* Plaintext, void* Ciphertext, const uint8_t* Keys) {
+     CryptoTDEA_CBCSpec CryptoSpec = {
+         .cryptFunc   = &CryptoEncrypt3KTDEA,
+         .blockSize   = CRYPTO_3KTDEA_BLOCK_SIZE
+     };
+     uint16_t numBlocks = (Count + CryptoSpec.blockSize - 1) / CryptoSpec.blockSize;
+     uint16_t blockIndex = 0;
+     uint8_t *ptBuf = (uint8_t *) Plaintext, *ctBuf = (uint8_t *) Ciphertext;
+     while(blockIndex < numBlocks) {
+        CryptoSpec.cryptFunc(ptBuf, ctBuf, Keys);
+        ptBuf += CryptoSpec.blockSize;
+        ctBuf += CryptoSpec.blockSize;
+        blockIndex++;
+    }
+}
+
+void Decrypt3DESBuffer(uint16_t Count, void* Plaintext, const void* Ciphertext, const uint8_t* Keys) {
+     CryptoTDEA_CBCSpec CryptoSpec = {
+         .cryptFunc   = &CryptoDecrypt3KTDEA,
+         .blockSize   = CRYPTO_3KTDEA_BLOCK_SIZE
+     };
+     uint16_t numBlocks = (Count + CryptoSpec.blockSize - 1) / CryptoSpec.blockSize;
+     uint16_t blockIndex = 0;
+     uint8_t *ptBuf = (uint8_t *) Plaintext, *ctBuf = (uint8_t *) Ciphertext;
+     while(blockIndex < numBlocks) {
+        CryptoSpec.cryptFunc(ptBuf, ctBuf, Keys);
+        ptBuf += CryptoSpec.blockSize;
+        ctBuf += CryptoSpec.blockSize;
+        blockIndex++;
+    }
+}

--- a/Firmware/Chameleon-Mini/Application/CryptoTDEA.h
+++ b/Firmware/Chameleon-Mini/Application/CryptoTDEA.h
@@ -32,10 +32,21 @@ PCD's side.
 #define CRYPTO_2KTDEA_KEY_SIZE      (CRYPTO_DES_KEY_SIZE * 2)
 #define CRYPTO_3KTDEA_KEY_SIZE      (CRYPTO_DES_KEY_SIZE * 3)
 
+typedef uint8_t Crypto2KTDEAKeyType[CRYPTO_2KTDEA_KEY_SIZE];
+typedef uint8_t Crypto3KTDEAKeyType[CRYPTO_3KTDEA_KEY_SIZE];
+
 #define CRYPTO_DES_BLOCK_SIZE       8 /* Bytes */
+#define CRYPTO_2KTDEA_BLOCK_SIZE             (CRYPTO_DES_BLOCK_SIZE)
+#define CRYPTO_3KTDEA_BLOCK_SIZE             (CRYPTO_DES_BLOCK_SIZE)
 
 /* Prototype the CBC function pointer in case anyone needs it */
 typedef void (*CryptoTDEACBCFuncType)(uint16_t Count, const void *Plaintext, void *Ciphertext, void *IV, const uint8_t *Keys);
+typedef void (*CryptoTDEAFuncType)(const void *PlainText, void *Ciphertext, const uint8_t *Keys);
+
+void CryptoEncryptDEA(void *Plaintext, void *Ciphertext, const uint8_t *Keys);
+void CryptoDecryptDEA(void *Plaintext, void *Ciphertext, const uint8_t *Keys);
+void EncryptDESBuffer(uint16_t Count, const void* Plaintext, void* Ciphertext, const uint8_t* Keys);
+void DecryptDESBuffer(uint16_t Count, void* Plaintext, const void* Ciphertext, const uint8_t* Keys);
 
 /** Performs the Triple DEA enciphering in ECB mode (single block)
  *
@@ -45,6 +56,13 @@ typedef void (*CryptoTDEACBCFuncType)(uint16_t Count, const void *Plaintext, voi
  */
 void CryptoEncrypt2KTDEA(const void *Plaintext, void *Ciphertext, const uint8_t *Keys);
 void CryptoDecrypt2KTDEA(const void *Plaintext, void *Ciphertext, const uint8_t *Keys);
+
+void CryptoEncrypt3KTDEA(void* Plaintext, void* Ciphertext, const uint8_t* Keys);
+void CryptoDecrypt3KTDEA(void* Plaintext, void* Ciphertext, const uint8_t* Keys);
+
+void Encrypt3DESBuffer(uint16_t Count, const void* Plaintext, void* Ciphertext, const uint8_t* Keys);
+void Decrypt3DESBuffer(uint16_t Count, void* Plaintext, const void* Ciphertext, const uint8_t* Keys);
+
 
 /** Performs the 2-key Triple DES en/deciphering in the CBC "send" mode (xor-then-crypt)
  *
@@ -80,6 +98,19 @@ void CryptoDecrypt2KTDEA_CBCReceive(uint16_t Count, const void *Input, void *Out
 void CryptoEncrypt3KTDEA_CBCSend(uint16_t Count, const void *Plaintext, void *Ciphertext, void *IV, const uint8_t *Keys);
 void CryptoDecrypt3KTDEA_CBCReceive(uint16_t Count, const void *Plaintext, void *Ciphertext, void *IV, const uint8_t *Keys);
 
+/* Spec for more generic send/recv encrypt/decrypt schemes: */
+typedef struct {
+    CryptoTDEAFuncType cryptFunc;
+    uint16_t           blockSize;
+} CryptoTDEA_CBCSpec;
+
+void CryptoTDEA_CBCSend(uint16_t Count, void* Plaintext, void* Ciphertext,
+                        void *IV, const uint8_t* Keys, CryptoTDEA_CBCSpec CryptoSpec);
+void CryptoTDEA_CBCRecv(uint16_t Count, void* Plaintext, void* Ciphertext,
+                        void *IV, const uint8_t* Keys, CryptoTDEA_CBCSpec CryptoSpec);
+
+uint8_t TransferEncryptTDEASend(uint8_t *Buffer, uint8_t Count);
+uint8_t TransferEncryptTDEAReceive(uint8_t *Buffer, uint8_t Count);
 
 /** Applies padding to the data within the buffer
  *

--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -8,7 +8,7 @@ SHELL = /bin/sh
 SETTINGS    += -DCONFIG_MF_CLASSIC_MINI_4B_SUPPORT
 SETTINGS    += -DCONFIG_MF_CLASSIC_1K_SUPPORT
 #SETTINGS    += -DCONFIG_MF_CLASSIC_1K_7B_SUPPORT
-SETTINGS    += -DCONFIG_MF_CLASSIC_4K_SUPPORT
+#SETTINGS    += -DCONFIG_MF_CLASSIC_4K_SUPPORT
 #SETTINGS    += -DCONFIG_MF_CLASSIC_4K_7B_SUPPORT
 SETTINGS    += -DCONFIG_MF_ULTRALIGHT_SUPPORT
 SETTINGS	+= -DCONFIG_ISO14443A_SNIFF_SUPPORT
@@ -17,7 +17,7 @@ SETTINGS	+= -DCONFIG_ISO14443A_READER_SUPPORT
 #SETTINGS	+= -DCONFIG_VICINITY_SUPPORT
 #SETTINGS	+= -DCONFIG_SL2S2002_SUPPORT
 #SETTINGS	+= -DCONFIG_TITAGITSTANDARD_SUPPORT
-SETTINGS	+= -DCONFIG_ISO15693_SNIFF_SUPPORT
+#SETTINGS	+= -DCONFIG_ISO15693_SNIFF_SUPPORT
 #SETTINGS	+= -DCONFIG_EM4233_SUPPORT
 
 #Support magic mode on mifare classic configuration
@@ -77,6 +77,13 @@ SETTINGS	+= -DDEFAULT_READER_THRESHOLD=400
 #Use EEPROM to store settings
 SETTINGS	+= -DENABLE_EEPROM_SETTINGS
 
+#Enable tests for DES/2KTDEA/3DES/AES128 crypto schemes:
+#SETTINGS  += -DENABLE_CRYPTO_TESTS
+
+#Enable a command to run any tests added by developers, e.g., the 
+#crypto scheme tests that can be enabled above:
+#SETTINGS  += -DENABLE_RUNTESTS_TERMINAL_COMMAND
+
 #Memory definitions and objcopy flags to include sections in binaries
 #FLASH_DATA_ADDR = 0x10000 #Start of data section in flash
 #FLASH_DATA_SIZE = 0x10000 #Size of data section in flash
@@ -103,8 +110,11 @@ OPTIMIZATION = s
 SRC         += $(TARGET).c LUFADescriptors.c System.c ISRSharing.S Configuration.c Random.c Common.c Memory.c MemoryAsm.S Button.c Log.c Settings.c LED.c Pin.c Map.c AntennaLevel.c
 SRC         += Terminal/Terminal.c Terminal/Commands.c Terminal/XModem.c Terminal/CommandLine.c
 SRC         += Codec/Codec.c Codec/ISO14443-2A.c Codec/Reader14443-2A.c Codec/SniffISO14443-2A.c Codec/Reader14443-ISR.S
-SRC         += Application/MifareUltralight.c Application/MifareClassic.c Application/ISO14443-3A.c Application/Crypto1.c Application/Reader14443A.c Application/Sniff14443A.c Application/CryptoTDEA.S
-SRC			+= Application/NTAG215.c
+SRC         += Application/MifareUltralight.c Application/MifareClassic.c Application/ISO14443-3A.c \
+			Application/Crypto1.c Application/Reader14443A.c Application/Sniff14443A.c \
+			Application/CryptoTDEA-HWAccelerated.S Application/CryptoTDEA.c Application/CryptoAES128.c \
+			Tests/CryptoTests.c Tests/ChameleonTerminal.c
+SRC		  += Application/NTAG215.c
 SRC         += Codec/ISO15693.c
 SRC         += Application/Vicinity.c Application/Sl2s2002.c Application/TITagitstandard.c Application/ISO15693-A.c Application/EM4233.c
 SRC         += $(LUFA_SRC_USB) $(LUFA_SRC_USBCLASS)
@@ -115,7 +125,8 @@ CC_FLAGS     = -g0 -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR)
 			   -std=gnu99 -Werror=implicit-function-declaration \
 			   -fno-inline-small-functions -fshort-enums -fpack-struct \
                   -ffunction-sections -Wl,--gc-sections --data-sections -ffunction-sections \
-                  -Wl,-relax -fno-split-wide-types -fno-tree-scev-cprop
+                  -Wl,-relax -fno-split-wide-types -fno-tree-scev-cprop \
+			   -fno-aggressive-loop-optimizations
 LD_FLAGS     = $(CC_FLAGS) -Wl,--section-start=.flashdata=$(FLASH_DATA_ADDR) -Wl,--section-start=.spmhelper=$(SPM_HELPER_ADDR)
 OBJDIR       = Bin
 OBJECT_FILES =

--- a/Firmware/Chameleon-Mini/Terminal/CommandLine.c
+++ b/Firmware/Chameleon-Mini/Terminal/CommandLine.c
@@ -330,6 +330,9 @@ const PROGMEM CommandEntryType CommandTable[] = {
         .SetFunc        = NO_FUNCTION,
         .GetFunc        = NO_FUNCTION
     },
+    #ifdef ENABLE_RUNTESTS_TERMINAL_COMMAND
+    #include "../Tests/ChameleonTerminalInclude.c"
+    #endif
     {
         /* This has to be last element */
         .Command    = COMMAND_LIST_END,

--- a/Firmware/Chameleon-Mini/Terminal/Commands.h
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.h
@@ -194,6 +194,10 @@ CommandStatusIdType CommandGetField(char *OutMessage);
 #define COMMAND_CLONE  "CLONE"
 CommandStatusIdType CommandExecClone(char *OutMessage);
 
+#ifdef ENABLE_RUNTESTS_TERMINAL_COMMAND
+    #include "../Tests/ChameleonTerminal.h"
+#endif
+
 #define COMMAND_LIST_END    ""
 /* Defines the end of command list. This is no actual command */
 

--- a/Firmware/Chameleon-Mini/Tests/ChameleonTerminal.c
+++ b/Firmware/Chameleon-Mini/Tests/ChameleonTerminal.c
@@ -1,0 +1,43 @@
+/* ChameleonTerminal.c */
+
+#ifdef ENABLE_RUNTESTS_TERMINAL_COMMAND
+
+#include "ChameleonTerminal.h"
+#include "CryptoTests.h"
+
+CommandStatusIdType CommandRunTests(char *OutParam) {
+     const ChameleonTestType testCases[] = {
+          #ifdef ENABLE_CRYPTO_TESTS
+          &CryptoTDEATestCase1, 
+          &CryptoTDEATestCase2, 
+          &CryptoAESTestCase1,
+          &CryptoAESTestCase2, 
+          #endif
+     };
+     uint32_t t;
+     uint16_t maxOutputChars = TERMINAL_BUFFER_SIZE, charCount = 0, testsFailedCount = 0;
+     bool statusPassed = true;
+     for(t = 0; t < ARRAY_COUNT(testCases); t++) {
+          if(!testCases[t](OutParam, maxOutputChars)) {
+               size_t opLength = StringLength(OutParam, maxOutputChars);
+               OutParam += opLength;
+               maxOutputChars -= opLength;
+               charCount = snprintf_P(OutParam, maxOutputChars, PSTR("> Test #% 2d ... [X]\r\n"), t + 1);
+               maxOutputChars = maxOutputChars < charCount ? 0 : maxOutputChars - charCount;
+               OutParam += charCount;
+               statusPassed = false;
+               ++testsFailedCount;
+          }
+     }
+     if(statusPassed) {
+          snprintf_P(OutParam, maxOutputChars, PSTR("All tests passed: %d / %d."), 
+                     ARRAY_COUNT(testCases), ARRAY_COUNT(testCases));
+     }
+     else {
+          snprintf_P(OutParam, maxOutputChars, PSTR("Tests failed: %d / %d."), 
+                     testsFailedCount, ARRAY_COUNT(testCases));
+     }
+     return COMMAND_INFO_OK_WITH_TEXT_ID;
+}
+
+#endif /* ENABLE_RUNTESTS_TERMINAL_COMMAND */

--- a/Firmware/Chameleon-Mini/Tests/ChameleonTerminal.h
+++ b/Firmware/Chameleon-Mini/Tests/ChameleonTerminal.h
@@ -1,0 +1,15 @@
+/* ChameleonTerminal.h */
+
+#ifndef __TESTS_CHAMELEON_TERMINAL_H__
+#define __TESTS_CHAMELEON_TERMINAL_H__
+
+#include "../Terminal/Commands.h"
+#include "../Terminal/CommandLine.h"
+#include "../Terminal/Terminal.h"
+
+typedef bool (*ChameleonTestType)(char*, uint16_t);
+
+#define COMMAND_RUNTESTS                 "RUNTESTS"
+CommandStatusIdType CommandRunTests(char *OutParam);
+
+#endif

--- a/Firmware/Chameleon-Mini/Tests/ChameleonTerminalInclude.c
+++ b/Firmware/Chameleon-Mini/Tests/ChameleonTerminalInclude.c
@@ -1,0 +1,12 @@
+/* ChameleonTerminalInclude.c */
+
+#ifndef __TESTS_CHAMELEON_TERMINAL_INCLUDE_C__
+#define __TESTS_CHAMELEON_TERMINAL_INCLUDE_C__
+     {
+          .Command        = COMMAND_RUNTESTS,
+          .ExecFunc       = CommandRunTests,
+          .ExecParamFunc  = NO_FUNCTION,
+          .SetFunc        = NO_FUNCTION,
+          .GetFunc        = NO_FUNCTION
+     },
+#endif

--- a/Firmware/Chameleon-Mini/Tests/CryptoTests.c
+++ b/Firmware/Chameleon-Mini/Tests/CryptoTests.c
@@ -1,0 +1,136 @@
+/* CryptoTests.c */
+
+#include "CryptoTests.h"
+
+bool CryptoTDEATestCase1(char *OutParam, uint16_t MaxOutputLength) {
+     const uint8_t ZeroBlock[CRYPTO_DES_BLOCK_SIZE] = {
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     };
+     const uint8_t TestKey2KTDEA[CRYPTO_2KTDEA_KEY_SIZE] = {
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+          0xcc, 0xaa, 0xff, 0xee, 0x11, 0x33, 0x33, 0x77,
+     };
+     const uint8_t TestOutput2KTDEAECB[CRYPTO_DES_BLOCK_SIZE] = {
+          0xcb, 0x5c, 0xfc, 0xeb, 0x00, 0x25, 0x1b, 0x60,
+     };
+     uint8_t Output[CRYPTO_DES_BLOCK_SIZE];
+     CryptoEncrypt2KTDEA(ZeroBlock, Output, TestKey2KTDEA);
+     if(memcmp(TestOutput2KTDEAECB, Output, sizeof(TestOutput2KTDEAECB))) {
+          strcat_P(OutParam, PSTR("> "));
+          OutParam += 2;
+          BufferToHexString(OutParam, MaxOutputLength - 2, Output, CRYPTO_DES_BLOCK_SIZE);
+          strcat_P(OutParam, PSTR("\r\n"));
+          return false;
+     }
+     return true;
+}
+
+bool CryptoTDEATestCase2(char *OutParam, uint16_t MaxOutputLength) {
+     const uint8_t TestKey2KTDEA[CRYPTO_2KTDEA_KEY_SIZE] = {
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+          0xcc, 0xaa, 0xff, 0xee, 0x11, 0x33, 0x33, 0x77,
+     };
+     const uint8_t TestInput2KTDEACBCReceive[CRYPTO_2KTDEA_KEY_SIZE] = {
+          0x27, 0xd2, 0x6c, 0x67, 0xc8, 0x49, 0xe5, 0xa5,
+          0x42, 0xa6, 0x8f, 0xe6, 0x82, 0x09, 0xa1, 0x1c,
+     };
+     const uint8_t TestOutput2KTDEACBCReceive[CRYPTO_2KTDEA_KEY_SIZE] = {
+          0x13, 0x37, 0xc0, 0xde, 0xca, 0xfe, 0xba, 0xbe,
+          0xde, 0xde, 0xde, 0xde, 0xad, 0xad, 0xad, 0xad,
+     };
+     uint8_t Output[2 * CRYPTO_DES_BLOCK_SIZE];
+     uint8_t IV[CRYPTO_DES_BLOCK_SIZE];
+     memset(IV, 0x00, sizeof(IV));
+     CryptoEncrypt2KTDEA_CBCReceive(2, TestInput2KTDEACBCReceive, Output, IV, TestKey2KTDEA);
+     if(memcmp(TestOutput2KTDEACBCReceive, Output, sizeof(TestOutput2KTDEACBCReceive))) {
+          strcat_P(OutParam, PSTR("> "));
+          OutParam += 2;
+          BufferToHexString(OutParam, MaxOutputLength - 2, Output, CRYPTO_2KTDEA_KEY_SIZE);
+          strcat_P(OutParam, PSTR("\r\n"));
+          return false;
+     }
+     return true;
+}
+
+bool CryptoAESTestCase1(char *OutParam, uint16_t MaxOutputLength) {
+     // Key from FIPS-197: 00010203 04050607 08090A0B 0C0D0E0
+     const uint8_t KeyData[CRYPTO_AES_KEY_SIZE] = {
+          0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+     };
+     // Plaintext from FIPS-197: 00112233 44556677 8899AABB CCDDEEFF
+     const uint8_t PlainText[CRYPTO_AES_BLOCK_SIZE] = {
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+		0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
+     };
+     // Cipher result from FIPS-197: 69c4e0d8 6a7b0430 d8cdb780 70b4c55a
+     const uint8_t CipherText[CRYPTO_AES_BLOCK_SIZE] = {
+          0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b, 0x04, 0x30,
+		0xd8, 0xcd, 0xb7, 0x80, 0x70, 0xb4, 0xc5, 0x5a
+     };
+     uint8_t tempBlock[CRYPTO_AES_BLOCK_SIZE];
+     CryptoAESConfig_t aesContext;
+     CryptoAESGetConfigDefaults(&aesContext);
+     aesContext.OpMode = CRYPTO_AES_CBC_MODE;
+     CryptoAESInitContext(&aesContext);
+     CryptoAESEncryptBuffer(CRYPTO_AES_BLOCK_SIZE, PlainText, tempBlock, NULL, KeyData);
+     if(memcmp(tempBlock, CipherText, CRYPTO_AES_BLOCK_SIZE)) {
+          strcat_P(OutParam, PSTR("> ENC: "));
+          OutParam += 7;
+          BufferToHexString(OutParam, MaxOutputLength - 7, tempBlock, CRYPTO_AES_BLOCK_SIZE);
+          strcat_P(OutParam, PSTR("\r\n"));
+          return false;
+     }
+     CryptoAESDecryptBuffer(CRYPTO_AES_BLOCK_SIZE, tempBlock, CipherText, NULL, KeyData);
+     if(memcmp(tempBlock, PlainText, CRYPTO_AES_BLOCK_SIZE)) {
+          strcat_P(OutParam, PSTR("> DEC: "));
+          OutParam += 7;
+          BufferToHexString(OutParam, MaxOutputLength - 7, tempBlock, CRYPTO_AES_BLOCK_SIZE);
+          strcat_P(OutParam, PSTR("\r\n"));
+          return false;
+     }
+     return true;
+}
+
+bool CryptoAESTestCase2(char *OutParam, uint16_t MaxOutputLength) {
+     // Example data taken from: 
+     // https://boringssl.googlesource.com/boringssl/+/2490/crypto/cipher/test/cipher_test.txt#104
+     const uint8_t KeyData[CRYPTO_AES_KEY_SIZE] = {
+          0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 
+          0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C
+     };
+     const uint8_t PlainText[CRYPTO_AES_BLOCK_SIZE] = {
+          0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96, 
+          0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A
+     };
+     const uint8_t CipherText[CRYPTO_AES_BLOCK_SIZE] = {
+          0x76, 0x49, 0xAB, 0xAC, 0x81, 0x19, 0xB2, 0x46, 
+          0xCE, 0xE9, 0x8E, 0x9B, 0x12, 0xE9, 0x19, 0x7D
+     };
+     const uint8_t IV[CRYPTO_AES_BLOCK_SIZE] = {
+          0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 
+          0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+     };
+     uint8_t tempBlock[CRYPTO_AES_BLOCK_SIZE];
+     CryptoAESConfig_t aesContext;
+     CryptoAESGetConfigDefaults(&aesContext);
+     aesContext.OpMode = CRYPTO_AES_CBC_MODE;
+     CryptoAESInitContext(&aesContext);
+     CryptoAESEncryptBuffer(CRYPTO_AES_BLOCK_SIZE, PlainText, tempBlock, IV, KeyData);
+     if(memcmp(tempBlock, CipherText, CRYPTO_AES_BLOCK_SIZE)) {
+          strcat_P(OutParam, PSTR("> ENC: "));
+          OutParam += 7;
+          BufferToHexString(OutParam, MaxOutputLength - 7, tempBlock, CRYPTO_AES_BLOCK_SIZE);
+          strcat_P(OutParam, PSTR("\r\n"));
+          return false;
+     }
+     CryptoAESDecryptBuffer(CRYPTO_AES_BLOCK_SIZE, tempBlock, CipherText, IV, KeyData);
+     if(memcmp(tempBlock, PlainText, CRYPTO_AES_BLOCK_SIZE)) {
+          strcat_P(OutParam, PSTR("> DEC: "));
+          OutParam += 7;
+          BufferToHexString(OutParam, MaxOutputLength - 7, tempBlock, CRYPTO_AES_BLOCK_SIZE);
+          strcat_P(OutParam, PSTR("\r\n"));
+          return false;
+     }
+     return true;
+}

--- a/Firmware/Chameleon-Mini/Tests/CryptoTests.c
+++ b/Firmware/Chameleon-Mini/Tests/CryptoTests.c
@@ -1,5 +1,7 @@
 /* CryptoTests.c */
 
+#ifdef ENABLE_CRYPTO_TESTS
+
 #include "CryptoTests.h"
 
 bool CryptoTDEATestCase1(char *OutParam, uint16_t MaxOutputLength) {
@@ -134,3 +136,5 @@ bool CryptoAESTestCase2(char *OutParam, uint16_t MaxOutputLength) {
      }
      return true;
 }
+
+#endif /* ENABLE_CRYPTO_TESTS */

--- a/Firmware/Chameleon-Mini/Tests/CryptoTests.h
+++ b/Firmware/Chameleon-Mini/Tests/CryptoTests.h
@@ -1,0 +1,38 @@
+/* CryptoTests.h */
+
+#ifdef ENABLE_CRYPTO_TESTS
+
+#ifndef __CRYPTO_TESTS_H__
+#define __CRYPTO_TESTS_H__
+
+#include "../Common.h"
+#include "../Terminal/Terminal.h"
+#include "../Application/CryptoTDEA.h"
+#include "../Application/CryptoAES128.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+/* DES crypto test cases: */
+
+/* Test 2KTDEA encryption, ECB mode: */
+bool CryptoTDEATestCase1(char *OutParam, uint16_t MaxOutputLength);
+
+/* Test 2KTDEA encryption, CBC receive mode: */
+bool CryptoTDEATestCase2(char *OutParam, uint16_t MaxOutputLength);
+
+/* AES-128 crypto test cases: */
+
+/* Test AES-128 encrypt/decrypt for a single block (ECB mode): */
+bool CryptoAESTestCase1(char *OutParam, uint16_t MaxOutputLength);
+
+/* Test AES-128 encrypt/decrypt for a single-block buffer (CBC mode, with an IV) -- Version 1: 
+ * Adapted from: https://github.com/eewiki/asf/blob/master/xmega/drivers/aes/example2/aes_example2.c
+ */
+bool CryptoAESTestCase2(char *OutParam, uint16_t MaxOutputLength);
+
+#endif /* __CRYPTO_TESTS_H__ */
+
+#endif /* ENABLE_CRYPTO_TESTS */


### PR DESCRIPTION
@david-oswald pointed out in [issue 10 in this repo](https://github.com/maxieds/ChameleonMiniDESFireStack/issues/10) that it is better to code the AES crypto support using the AVR Xmega built-in hardware acceleration (in place of the previous [software implementation](https://github.com/maxieds/ChameleonMiniDESFireStack/tree/master/Firmware/Chameleon-Mini/Application/DESFire/ExternalCryptoLib/ArduinoCryptoLib/aes)). In making the revisions in this pull request, I updated the existing DES/3DES/2KTDEA support added by @dev-zzo and created the new AES-128 HW accelerated functionality based on source code samples from Microchip's [ASF library for Xmega](https://github.com/avrxml/asf/tree/master/xmega/drivers/aes). 

To test these routines, enable the following new settings flags in the ``Makefile``:
```make
#Enable tests for DES/2KTDEA/3DES/AES128 crypto schemes:
SETTINGS  += -DENABLE_CRYPTO_TESTS

#Enable a command to run any tests added by developers, e.g., the 
#crypto scheme tests that can be enabled above:
SETTINGS  += -DENABLE_RUNTESTS_TERMINAL_COMMAND
```
Then after recompiling and refreshing, the following command output of the new Chameleon terminal command ``RUNTESTS`` shows that the cryptographic routine test cases all pass: 
```bash
RUNTESTS                                
101:OK WITH TEXT                        
All tests passed: 4 / 4.
```
Note that enabling the crypto tests brings in extra memory requirements, so make sure to remove that setting by default in the ``Makefile``.