### PR TITLE
docs: fix simple typo, uncommnted -> uncommented

### DIFF
--- a/Firmware/Chameleon-Mini/Application/EM4233.c
+++ b/Firmware/Chameleon-Mini/Application/EM4233.c
@@ -4,7 +4,7 @@
  *  Created on: 12-05-2018
  *      Author: ceres-c & MrMoDDoM
  *  Notes:
- *      - In EM4233.h you can find the define EM4233_LOGIN_YES_CARD that has to be uncommnted
+ *      - In EM4233.h you can find the define EM4233_LOGIN_YES_CARD that has to be uncommented
  *        to allow any login request without checking the password.
  *
  *  TODO:


### PR DESCRIPTION
There is a small typo in Firmware/Chameleon-Mini/Application/EM4233.c.

Should read `uncommented` rather than `uncommnted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md