### PR TITLE
AUTOCALIBRATE command for Sniff-ISO15693 application

### DIFF
--- a/Firmware/Chameleon-Mini/Application/Sniff15693.c
+++ b/Firmware/Chameleon-Mini/Application/Sniff15693.c
@@ -155,9 +155,15 @@ INLINE void SniffISO15693IncrementThreshold(void){
 
 uint16_t SniffISO15693AppProcess(uint8_t* FrameBuf, uint16_t FrameBytes)
 {
+
+    bool crc_chk = ISO15693CheckCRC(FrameBuf, FrameBytes-ISO15693_CRC16_SIZE);
+
 #ifdef ISO15693_DEBUG_LOG
     char str[64];
-#endif
+    sprintf(str, "Sniff15693: CrcCheck result=%d", crc_chk);
+    LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+#endif /*#ifdef ISO15693_DEBUG_LOG*/
+
     switch (Sniff15693CurrentCommand) {
         case Sniff15693_Do_Nothing: {
             return 0;
@@ -187,15 +193,17 @@ uint16_t SniffISO15693AppProcess(uint8_t* FrameBuf, uint16_t FrameBytes)
                         }
                         last_cycle_successful = false;
                     }else{
-                        /* We have received card data now */
-                        /* Threshold is in a good range */
-                        /* if min_succ_th was never set ( == 0) */
-                        /* Set it now to the current threshold */
-                        if (min_succ_th == 0)
-                            min_succ_th = GlobalSettings.ActiveSettingPtr->ReaderThreshold;
-                        last_cycle_successful = true;
+                        if (crc_chk){
+                            /* We have received card data now */
+                            /* Threshold is in a good range */
+                            /* if min_succ_th was never set ( == 0) */
+                            /* Set it now to the current threshold */
+                            if (min_succ_th == 0)
+                                min_succ_th = GlobalSettings.ActiveSettingPtr->ReaderThreshold;
+                            last_cycle_successful = true;
+                        }
 #ifdef ISO15693_DEBUG_LOG
-                        sprintf(str, "Sniff15693: Found card data (%d) ", min_succ_th);
+                        sprintf(str, "Sniff15693: Found card data (%d) - crc=%d", min_succ_th, crc_chk);
                         LogEntry(LOG_INFO_GENERIC, str, strlen(str));
 #endif /*#ifdef ISO15693_DEBUG_LOG*/
                         autocalib_state = AUTOCALIB_CARD_DATA;
@@ -204,15 +212,17 @@ uint16_t SniffISO15693AppProcess(uint8_t* FrameBuf, uint16_t FrameBytes)
                     break;
                 case(AUTOCALIB_CARD_DATA): /* Means last time we have received card data */
                     if(SniffTrafficSource == TRAFFIC_CARD){
-                        /* We have received card data now */
-                        /* Threshold is in a good range */
-                        /* if min_succ_th was never set ( == 0) */
-                        /* Set it now to the current threshold */
-                        if (min_succ_th == 0)
-                            min_succ_th = GlobalSettings.ActiveSettingPtr->ReaderThreshold;
-                        last_cycle_successful = true;
+                        if (crc_chk){
+                            /* We have received card data now */
+                            /* Threshold is in a good range */
+                            /* if min_succ_th was never set ( == 0) */
+                            /* Set it now to the current threshold */
+                            if (min_succ_th == 0)
+                                min_succ_th = GlobalSettings.ActiveSettingPtr->ReaderThreshold;
+                            last_cycle_successful = true;
+                        }
 #ifdef ISO15693_DEBUG_LOG
-                        sprintf(str, "Sniff15693: Found card data (%d) ", min_succ_th);
+                        sprintf(str, "Sniff15693: Found card data (%d) - crc=%d", min_succ_th, crc_chk);
                         LogEntry(LOG_INFO_GENERIC, str, strlen(str));
 #endif /*#ifdef ISO15693_DEBUG_LOG*/
                         SniffISO15693IncrementThreshold();

--- a/Firmware/Chameleon-Mini/Application/Sniff15693.c
+++ b/Firmware/Chameleon-Mini/Application/Sniff15693.c
@@ -10,7 +10,58 @@
 #include "../Codec/SniffISO15693.h"
 #include "Sniff15693.h"
 
+/* Incrementing in steps of 50 was considered as sufficiently */
+/* accurate during tests */
+#define ISO15693_TH_CALIBRATE_STEPS    50
+//#define ISO15693_DEBUG_LOG
+typedef enum {
+    AUTOCALIB_INIT,
+    AUTOCALIB_READER_DATA,
+    AUTOCALIB_CARD_DATA,
+} Sniff15693State;
+
 Sniff15693Command Sniff15693CurrentCommand;
+static Sniff15693State autocalib_state = AUTOCALIB_INIT;
+
+/* The Autocalib shall work as following: */
+/* Calls to AppProcess shall always alternate b/w ReaderData and CardData */
+/* If there are 2 successive calls to to AppProcess with ReaderData, it means */
+/*   we have not received card data -> bad case */
+/* So, we need always two calls to AppProcess to evaluate b/w good & bad case */
+/* two calls are called a cycle further on */
+/* we do increment the threshold after each cycle */
+/* We store the first successfull card data as min_succ_th (means the threshold when we have received */
+/* card data the first time */
+/* And now we increment the threshold further, until we dont get card data anymore */
+/* This will be stored in 'max_succ_th */
+/* We do assume now, that the optimal threshold is between min_succ_th and max_succ_th */
+/* With this approach we do avoid, to maintain a large array of possible thresholds */
+/* The serach range is defined by the DemodFloorNoiseLevel */
+/* We search b/w: */
+/*   0.5 * DemodFloorNoiseLevel --> 1.5 * DemodFloorNoiseLevel */
+
+
+/*
+                _________________________ scanning range ______________________________________
+               /                                                                               \
+    -|---------|-----------------------------------------threshold-----------------------------|------------>
+               |                                                                               |
+typical pattern|                                                                               |
+- bad case     |------------------------+-++++-+-+---------------------------------------------|
++ good case    |                        |        |                                             |
+               |                   min_succ_th   |                                             |
+               |                               max_succ_th                                     |
+             min_th                                                                           max_th
+
+   And finally the desired threshold is: (min_succ_th + max_succ_th) >> 1
+*/
+static uint16_t curr_th = 0;
+static uint16_t min_th = 0;
+static uint16_t max_th = 0xFFF;
+static uint16_t min_succ_th = 0;
+static uint16_t max_succ_th = 0xFFF;
+
+static bool last_cycle_successful = false;
 
 void SniffISO15693AppTimeout(void)
 {
@@ -20,6 +71,7 @@ void SniffISO15693AppTimeout(void)
 void SniffISO15693AppInit(void)
 {
     Sniff15693CurrentCommand = Sniff15693_Do_Nothing;
+    autocalib_state = AUTOCALIB_INIT;
 }
 
 void SniffISO15693AppReset(void)
@@ -38,17 +90,139 @@ void SniffISO15693AppTick(void)
 
 }
 
+INLINE void SniffISO15693InitAutocalib(void){
+    uint16_t floor_noise = SniffISO15693GetFloorNoise();
+    /* We search b/w: */
+    /*   0.5 * DemodFloorNoiseLevel --> 1.5 * DemodFloorNoiseLevel */
+    min_th = floor_noise >> 1;
+    max_th = floor_noise + (floor_noise >> 1);
+    if(min_th >= max_th) {
+        min_th = 0;
+        max_th = 0xFFF;
+    }
+
+    min_succ_th = 0;
+    max_succ_th = 0xFFF;
+
+    last_cycle_successful = false;
+#ifdef ISO15693_DEBUG_LOG
+    {
+        char str[64];
+        sprintf(str, "Sniff15693: Start Autocalibration %d - %d ", min_th, max_th);
+        LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+    }
+#endif /*#ifdef ISO15693_DEBUG_LOG*/
+    curr_th = min_th;
+    CodecThresholdSet(curr_th);
+    return;
+}
+
+INLINE void SniffISO15693FinishAutocalib(void){
+    uint16_t new_th;
+    new_th = (min_succ_th + max_succ_th) >> 1;
+    CodecThresholdSet(new_th);
+#ifdef ISO15693_DEBUG_LOG
+    {
+        char str[64];
+        sprintf(str, "Sniff15693: Finished Autocalibration %d - %d --> % d", min_succ_th, max_succ_th, new_th);
+        LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+    }
+#endif /*#ifdef ISO15693_DEBUG_LOG*/
+    SniffISO15693AppInit();
+    CommandLinePendingTaskFinished(COMMAND_INFO_OK_WITH_TEXT_ID, NULL);
+    //CommandLinePendingTaskFinished(COMMAND_INFO_FALSE_ID, NULL);
+}
+
+INLINE void SniffISO15693IncrementThreshold(void){
+
+    /* So increment the threshold */
+    /* Steps of 3*16=48 are sufficient for us */
+    curr_th += ISO15693_TH_CALIBRATE_STEPS;
+    CodecThresholdSet(curr_th);
+#ifdef ISO15693_DEBUG_LOG
+    {
+        char str[64];
+        sprintf(str, "Sniff15693: Try next th=%d", curr_th);
+        LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+    }
+#endif /*#ifdef ISO15693_DEBUG_LOG*/
+    if(curr_th >= max_th) {
+        /* We are finished now */
+        /* Evaluate the results */
+        SniffISO15693FinishAutocalib();
+    }
+}
+
 uint16_t SniffISO15693AppProcess(uint8_t* FrameBuf, uint16_t FrameBytes)
 {
+#ifdef ISO15693_DEBUG_LOG
     char str[64];
+#endif
     switch (Sniff15693CurrentCommand) {
         case Sniff15693_Do_Nothing: {
             return 0;
         }
         case Sniff15693_Autocalibrate: {
-            sprintf(str, "CMD: Sniff15693_Autocalibrate ");
-            LogEntry(LOG_INFO_GENERIC, str, strlen(str));
-            CommandLinePendingTaskFinished(COMMAND_INFO_FALSE_ID, NULL);
+            switch(autocalib_state){
+                case(AUTOCALIB_INIT):
+                    SniffISO15693InitAutocalib();
+                    if(SniffTrafficSource == TRAFFIC_CARD)
+                        autocalib_state = AUTOCALIB_CARD_DATA;
+                    else
+                        autocalib_state = AUTOCALIB_READER_DATA;
+                    break;
+                case(AUTOCALIB_READER_DATA): /* Means last time we have received reader data */
+                    if(SniffTrafficSource == TRAFFIC_READER){
+                        /* Second time Reader Data received */
+                        /* This means no card data received */
+                        /* If we had successful tries before */
+                        /* we need to record it as threshold max here */
+                        if(last_cycle_successful == true){
+                            max_succ_th = GlobalSettings.ActiveSettingPtr->ReaderThreshold -
+                                            CODEC_THRESHOLD_CALIBRATE_STEPS;
+#ifdef ISO15693_DEBUG_LOG
+                            sprintf(str, "Sniff15693: Updated max_succ_th (%d) ", max_succ_th);
+                            LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+#endif /*#ifdef ISO15693_DEBUG_LOG*/
+                        }
+                        last_cycle_successful = false;
+                    }else{
+                        /* We have received card data now */
+                        /* Threshold is in a good range */
+                        /* if min_succ_th was never set ( == 0) */
+                        /* Set it now to the current threshold */
+                        if (min_succ_th == 0)
+                            min_succ_th = GlobalSettings.ActiveSettingPtr->ReaderThreshold;
+                        last_cycle_successful = true;
+#ifdef ISO15693_DEBUG_LOG
+                        sprintf(str, "Sniff15693: Found card data (%d) ", min_succ_th);
+                        LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+#endif /*#ifdef ISO15693_DEBUG_LOG*/
+                        autocalib_state = AUTOCALIB_CARD_DATA;
+                    }
+                    SniffISO15693IncrementThreshold();
+                    break;
+                case(AUTOCALIB_CARD_DATA): /* Means last time we have received card data */
+                    if(SniffTrafficSource == TRAFFIC_CARD){
+                        /* We have received card data now */
+                        /* Threshold is in a good range */
+                        /* if min_succ_th was never set ( == 0) */
+                        /* Set it now to the current threshold */
+                        if (min_succ_th == 0)
+                            min_succ_th = GlobalSettings.ActiveSettingPtr->ReaderThreshold;
+                        last_cycle_successful = true;
+#ifdef ISO15693_DEBUG_LOG
+                        sprintf(str, "Sniff15693: Found card data (%d) ", min_succ_th);
+                        LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+#endif /*#ifdef ISO15693_DEBUG_LOG*/
+                        SniffISO15693IncrementThreshold();
+                    }else{
+                        autocalib_state = AUTOCALIB_READER_DATA;
+                    }
+                    break;
+                default:
+                    break;
+            }
             return 0;
         }
     }

--- a/Firmware/Chameleon-Mini/Application/Sniff15693.c
+++ b/Firmware/Chameleon-Mini/Application/Sniff15693.c
@@ -10,12 +10,21 @@
 #include "../Codec/SniffISO15693.h"
 #include "Sniff15693.h"
 
+Sniff15693Command Sniff15693CurrentCommand;
+
+void SniffISO15693AppTimeout(void)
+{
+    SniffISO15693AppReset();
+}
+
 void SniffISO15693AppInit(void)
 {
+    Sniff15693CurrentCommand = Sniff15693_Do_Nothing;
 }
 
 void SniffISO15693AppReset(void)
 {
+    SniffISO15693AppInit();
 }
 
 
@@ -27,11 +36,22 @@ void SniffISO15693AppTask(void)
 void SniffISO15693AppTick(void)
 {
 
-    
 }
 
 uint16_t SniffISO15693AppProcess(uint8_t* FrameBuf, uint16_t FrameBytes)
 {
+    char str[64];
+    switch (Sniff15693CurrentCommand) {
+        case Sniff15693_Do_Nothing: {
+            return 0;
+        }
+        case Sniff15693_Autocalibrate: {
+            sprintf(str, "CMD: Sniff15693_Autocalibrate ");
+            LogEntry(LOG_INFO_GENERIC, str, strlen(str));
+            CommandLinePendingTaskFinished(COMMAND_INFO_FALSE_ID, NULL);
+            return 0;
+        }
+    }
     return 0;
 }
 

--- a/Firmware/Chameleon-Mini/Application/Sniff15693.h
+++ b/Firmware/Chameleon-Mini/Application/Sniff15693.h
@@ -1,5 +1,5 @@
 /*
- * SniffISO15693.h
+ * Sniff15693.h
  *
  *  Created on: 05.11.2019
  *      Author: ceres-c
@@ -16,5 +16,13 @@ void SniffISO15693AppReset(void);
 void SniffISO15693AppTask(void);
 void SniffISO15693AppTick(void);
 uint16_t SniffISO15693AppProcess(uint8_t* FrameBuf, uint16_t FrameBytes);
+void SniffISO15693AppTimeout(void);
+
+typedef enum {
+    Sniff15693_Do_Nothing,
+    Sniff15693_Autocalibrate,
+} Sniff15693Command;
+
+extern Sniff15693Command Sniff15693CurrentCommand;
 
 #endif /* SNIFF_15693_H_ */

--- a/Firmware/Chameleon-Mini/Codec/SniffISO15693.h
+++ b/Firmware/Chameleon-Mini/Codec/SniffISO15693.h
@@ -32,6 +32,18 @@ void SniffISO15693CodecTask(void);
 /* Application Interface */
 void SniffISO15693CodecStart(void);
 void SniffISO15693CodecReset(void);
+/* Can be used by an application to disable */
+/* The auto-threshold algorithm */
+/* This is needed in corner cases - where the algo doesnt */
+/* find a proper threshold */
+/* In this case, the application can run an autocalibration session */
+void SniffISO15693CtrlAutoThreshold(bool enable);
+bool SniffISO15693GetAutoThreshold(void);
+
+/* Function is used to receive the measured FloorNoise */
+/* This is used to narrow down the range, which is considered for */
+/* Threshold */
+uint16_t SniffISO15693GetFloorNoise(void);
 
 /* Internal functions */
 INLINE void SNIFF_ISO15693_READER_EOC_VCD(void);

--- a/Firmware/Chameleon-Mini/Terminal/CommandLine.c
+++ b/Firmware/Chameleon-Mini/Terminal/CommandLine.c
@@ -334,6 +334,15 @@ const PROGMEM CommandEntryType CommandTable[] = {
         .GetFunc        = NO_FUNCTION
     },
 #endif
+#ifdef CONFIG_ISO15693_SNIFF_SUPPORT
+    {
+        .Command        = COMMAND_AUTOTHRESHOLD,
+        .ExecFunc       = NO_FUNCTION,
+        .ExecParamFunc  = NO_FUNCTION,
+        .SetFunc        = CommandSetAutoThreshold,
+        .GetFunc        = CommandGetAutoThreshold
+    },
+#endif
 #ifdef ENABLE_RUNTESTS_TERMINAL_COMMAND
 #include "../Tests/ChameleonTerminalInclude.c"
 #endif

--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -16,6 +16,7 @@
 #include "../Battery.h"
 #include "../Codec/Codec.h"
 #include "../Application/Reader14443A.h"
+#include "../Application/Sniff15693.h"
 
 extern Reader14443Command Reader14443CurrentCommand;
 extern Sniff14443Command Sniff14443CurrentCommand;
@@ -653,6 +654,15 @@ CommandStatusIdType CommandExecAutocalibrate(char *OutMessage) {
         Sniff14443CurrentCommand = Sniff14443_Autocalibrate;
         Sniff14443AAppInit();
         CommandLinePendingTaskTimeout = &Sniff14443AAppTimeout;
+        return TIMEOUT_COMMAND;
+    }
+#endif
+#ifdef CONFIG_ISO15693_SNIFF_SUPPORT
+    if (GlobalSettings.ActiveSettingPtr->Configuration == CONFIG_ISO15693_SNIFF) {
+        ApplicationReset();
+
+        Sniff15693CurrentCommand = Sniff15693_Autocalibrate;
+        CommandLinePendingTaskTimeout = &SniffISO15693AppTimeout;
         return TIMEOUT_COMMAND;
     }
 #endif

--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -661,7 +661,10 @@ CommandStatusIdType CommandExecAutocalibrate(char *OutMessage) {
     }
 #endif
 #ifdef CONFIG_ISO15693_SNIFF_SUPPORT
-    if (GlobalSettings.ActiveSettingPtr->Configuration == CONFIG_ISO15693_SNIFF) {
+    /* Only execute autocalibration if the codec does not use autothreshold */
+    /* It needs to be disabled by the AUTOTHRESHOLD=DISABLE command */
+    if ((GlobalSettings.ActiveSettingPtr->Configuration == CONFIG_ISO15693_SNIFF) &&
+        (SniffISO15693GetAutoThreshold() == false)){
         ApplicationReset();
 
         Sniff15693CurrentCommand = Sniff15693_Autocalibrate;

--- a/Firmware/Chameleon-Mini/Terminal/Commands.h
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.h
@@ -194,6 +194,12 @@ CommandStatusIdType CommandGetField(char *OutMessage);
 #define COMMAND_CLONE  "CLONE"
 CommandStatusIdType CommandExecClone(char *OutMessage);
 
+#ifdef CONFIG_ISO15693_SNIFF_SUPPORT
+#define COMMAND_AUTOTHRESHOLD     "AUTOTHRESHOLD"
+CommandStatusIdType CommandGetAutoThreshold(char *OutParam);
+CommandStatusIdType CommandSetAutoThreshold(char *OutMessage, const char *InParam);
+#endif /*#ifdef CONFIG_ISO15693_SNIFF_SUPPORT*/
+
 #ifdef ENABLE_RUNTESTS_TERMINAL_COMMAND
 #include "../Tests/ChameleonTerminal.h"
 #endif

--- a/Software/ChamTool/Chameleon/Device.py
+++ b/Software/ChamTool/Chameleon/Device.py
@@ -28,6 +28,7 @@ class Device:
     COMMAND_RED_LED = "LEDRED"
     COMMAND_THRESHOLD = "THRESHOLD"
     COMMAND_AUTOCALIBRATE = "AUTOCALIBRATE"
+    COMMAND_AUTOTHRESHOLD = "AUTOTHRESHOLD"
     COMMAND_UPGRADE = "upgrade"
 
     STATUS_CODE_OK = 100
@@ -280,7 +281,10 @@ class Device:
 
     def cmdAutoCalibrate(self):
        return self.returnCmd(self.COMMAND_AUTOCALIBRATE)
-       
+
+    def cmdAutoThreshold(self, newLogMode):
+        return self.getSetCmd(self.COMMAND_AUTOTHRESHOLD, newLogMode)
+
     def cmdUpgrade(self):
         # Execute command
         cmdLine = self.COMMAND_UPGRADE + self.LINE_ENDING

--- a/Software/ChamTool/Chameleon/Device.py
+++ b/Software/ChamTool/Chameleon/Device.py
@@ -27,6 +27,7 @@ class Device:
     COMMAND_GREEN_LED = "LEDGREEN"
     COMMAND_RED_LED = "LEDRED"
     COMMAND_THRESHOLD = "THRESHOLD"
+    COMMAND_AUTOCALIBRATE = "AUTOCALIBRATE"
     COMMAND_UPGRADE = "upgrade"
 
     STATUS_CODE_OK = 100
@@ -277,6 +278,9 @@ class Device:
         else:
             return self.getSetCmd(self.COMMAND_THRESHOLD, value)
 
+    def cmdAutoCalibrate(self):
+       return self.returnCmd(self.COMMAND_AUTOCALIBRATE)
+       
     def cmdUpgrade(self):
         # Execute command
         cmdLine = self.COMMAND_UPGRADE + self.LINE_ENDING

--- a/Software/ChamTool/chamtool.py
+++ b/Software/ChamTool/chamtool.py
@@ -177,6 +177,18 @@ def cmdThreshold(chameleon, arg):
         else:
             return "Setting threshold failed: {}".format(arg, result['statusText'])
 
+def cmdAutoCalibrate(chameleon, arg):
+
+    if (len(arg) == 0):
+        result = chameleon.cmdAutoCalibrate()
+        if (result['statusCode'] in chameleon.STATUS_CODES_SUCCESS):
+            return "Autocalibration successfully executed {}".format(result['statusText'])
+        else:
+            return "Error during autocalibration: {}".format(result['statusText'])
+        
+    else:
+        return "Command failed - No Parameter expected ! {}".format(arg)
+          
 def cmdUpgrade(chameleon, arg):
     if(chameleon.cmdUpgrade() == 0):
         print ("Device changed into Upgrade Mode")
@@ -223,6 +235,7 @@ def main():
     cmdArgGroup.add_argument("-gl",  "--gled",       dest="gled",        action=CmdListAction, metavar="FUNCTION", nargs='?', help="retrieve or set the current green led function")
     cmdArgGroup.add_argument("-rl",  "--rled",       dest="rled",        action=CmdListAction, metavar="FUNCTION", nargs='?', help="retrieve or set the current red led function")
     cmdArgGroup.add_argument("-th",  "--threshold",  dest="threshold",   action=CmdListAction, nargs='?', help="retrieve or set the threshold")
+    cmdArgGroup.add_argument("-ac",  "--autocalibrate",  dest="auto_calib",   action=CmdListAction, nargs=0, help="Send AutoCalibration command")
     cmdArgGroup.add_argument("-ug",  "--upgrade",    dest="upgrade",     action=CmdListAction, nargs=0,   help="set the micro Controller to upgrade mode")
 
     args = argParser.parse_args()
@@ -257,6 +270,7 @@ def main():
                 "gled"      : cmdGreenLED,
                 "rled"      : cmdRedLED,
                 "threshold" : cmdThreshold,
+                "auto_calib": cmdAutoCalibrate,
                 "upgrade"   : cmdUpgrade,
             }
 

--- a/Software/ChamTool/chamtool.py
+++ b/Software/ChamTool/chamtool.py
@@ -188,6 +188,17 @@ def cmdAutoCalibrate(chameleon, arg):
         
     else:
         return "Command failed - No Parameter expected ! {}".format(arg)
+
+def cmdAutoThreshold(chameleon, arg):
+    result = chameleon.cmdAutoThreshold(arg)
+
+    if (arg is None):
+        return "Autothreshold is: {}".format(result['response'])
+    else:
+        if (result['statusCode'] in chameleon.STATUS_CODES_SUCCESS):
+            return "Autothreshold is now {}".format(arg)
+        else:
+            return "Setting Autothreshold failed: {}".format(arg, result['statusText'])
           
 def cmdUpgrade(chameleon, arg):
     if(chameleon.cmdUpgrade() == 0):
@@ -236,6 +247,7 @@ def main():
     cmdArgGroup.add_argument("-rl",  "--rled",       dest="rled",        action=CmdListAction, metavar="FUNCTION", nargs='?', help="retrieve or set the current red led function")
     cmdArgGroup.add_argument("-th",  "--threshold",  dest="threshold",   action=CmdListAction, nargs='?', help="retrieve or set the threshold")
     cmdArgGroup.add_argument("-ac",  "--autocalibrate",  dest="auto_calib",   action=CmdListAction, nargs=0, help="Send AutoCalibration command")
+    cmdArgGroup.add_argument("-at",  "--autothreshold",  dest="auto_thres",   action=CmdListAction, metavar="0/1", nargs='?', help="DIS-/ENABLES Autothreshold for SniffIso15693 Codec")
     cmdArgGroup.add_argument("-ug",  "--upgrade",    dest="upgrade",     action=CmdListAction, nargs=0,   help="set the micro Controller to upgrade mode")
 
     args = argParser.parse_args()
@@ -271,6 +283,7 @@ def main():
                 "rled"      : cmdRedLED,
                 "threshold" : cmdThreshold,
                 "auto_calib": cmdAutoCalibrate,
+                "auto_thres": cmdAutoThreshold,
                 "upgrade"   : cmdUpgrade,
             }
 


### PR DESCRIPTION
This adds code to the Sniff15693 Application to run the AUTOCALIBRATE command.
But default, the Sniff15693 codec uses an Autothreshold detection - if this works fine, it shall be used.
If not you can disable it by un-commenting this line in the Makefile:
     #CONFIG_SETTINGS += -DSNIFF15693_DISABLE_AUTO_THRESHOLD

The AUTOCALIBRATION algorithm itself is explained in the source code (Application/Sniff15693.c) 