### PR TITLE
Basic Gallagher support on DESFire

### DIFF
--- a/Firmware/Chameleon-Mini/Application/CryptoCMAC.h
+++ b/Firmware/Chameleon-Mini/Application/CryptoCMAC.h
@@ -42,4 +42,6 @@ bool checkBufferMAC(uint8_t *bufferData, uint16_t bufferSize, uint16_t checksumS
 uint16_t appendBufferMAC(const uint8_t *keyData, uint8_t *bufferData, uint16_t bufferSize);
 bool checkBufferCMAC(uint8_t *bufferData, uint16_t bufferSize, uint16_t checksumSize);
 
+bool DesfireCryptoCMAC(uint8_t cryptoType, const uint8_t *keyData, uint8_t *bufferDataIn, uint16_t bufferSize, uint8_t *IV, uint8_t *cmac);
+
 #endif

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireApplicationDirectory.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireApplicationDirectory.c
@@ -208,8 +208,8 @@ void SetAppProperty(DesfireCardLayout propId, BYTE AppSlot, SIZET Value) {
 
 bool KeyIdValid(uint8_t AppSlot, uint8_t KeyId) {
     if (KeyId >= DESFIRE_MAX_KEYS || KeyId >= ReadMaxKeyCount(AppSlot)) {
-        const char *debugMsg = PSTR("INVKEY-KeyId(%02x)-RdMax(%02x)");
-        DEBUG_PRINT_P(debugMsg, KeyId, ReadMaxKeyCount(AppSlot));
+        const char *debugMsg = PSTR("INVKEY-KeyId(%02x)-RdMax(%02x),App(%02x)");
+        DEBUG_PRINT_P(debugMsg, KeyId, ReadMaxKeyCount(AppSlot), AppSlot);
         return false;
     }
     return true;

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireApplicationDirectory.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireApplicationDirectory.c
@@ -304,10 +304,12 @@ void ReadAppKey(uint8_t AppSlot, uint8_t KeyId, uint8_t *Key, SIZET KeySize) {
     } else if (KeySize > CRYPTO_MAX_KEY_SIZE) {
         return;
     }
+
     SIZET keyStorageArrayBlockId = ReadKeyStorageAddress(AppSlot);
-    SIZET keyStorageArray[DESFIRE_MAX_KEYS];
-    ReadBlockBytes(keyStorageArray, keyStorageArrayBlockId, 2 * DESFIRE_MAX_KEYS);
-    ReadBlockBytes(Key, keyStorageArray[KeyId], KeySize);
+
+    SIZET keyBlockID;
+    ReadBlockBytes(&keyBlockID, keyStorageArrayBlockId + (sizeof(SIZET) * KeyId), sizeof(SIZET));
+    ReadBlockBytes(Key, keyBlockID, KeySize);
 }
 
 void WriteAppKey(uint8_t AppSlot, uint8_t KeyId, const uint8_t *Key, SIZET KeySize) {
@@ -316,10 +318,12 @@ void WriteAppKey(uint8_t AppSlot, uint8_t KeyId, const uint8_t *Key, SIZET KeySi
     } else if (KeySize > CRYPTO_MAX_KEY_SIZE) {
         return;
     }
+
     SIZET keyStorageArrayBlockId = ReadKeyStorageAddress(AppSlot);
-    SIZET keyStorageArray[DESFIRE_MAX_KEYS];
-    ReadBlockBytes(keyStorageArray, keyStorageArrayBlockId, 2 * DESFIRE_MAX_KEYS);
-    WriteBlockBytes(Key, keyStorageArray[KeyId], KeySize);
+
+    SIZET keyBlockID;
+    ReadBlockBytes(&keyBlockID, keyStorageArrayBlockId + (sizeof(SIZET) * KeyId), sizeof(SIZET));
+    WriteBlockBytes(Key, keyBlockID, KeySize);
 }
 
 /*
@@ -662,11 +666,14 @@ uint16_t CreateApp(const DESFireAidType Aid, uint8_t KeyCount, uint8_t KeySettin
     } else {
         SIZET keyAddresses[DESFIRE_MAX_KEYS];
         memset(keyAddresses, 0x00, sizeof(SIZET) * DESFIRE_MAX_KEYS);
-        // Allocate the application Master Key:
-        keyAddresses[0] = AllocateBlocks(APP_CACHE_MAX_KEY_BLOCK_SIZE);
-        if (keyAddresses[0] == 0) {
-            return STATUS_OUT_OF_EEPROM_ERROR;
+        // Allocate space for all keys:
+        for (uint8_t i = 0; i < KeyCount; ++i) {
+            keyAddresses[i] = AllocateBlocks(APP_CACHE_MAX_KEY_BLOCK_SIZE);
+            if (keyAddresses[i] == 0) {
+                return STATUS_OUT_OF_EEPROM_ERROR;
+            }
         }
+
         BYTE cryptoBlankKeyData[CRYPTO_MAX_KEY_SIZE];
         memset(cryptoBlankKeyData, 0x00, CRYPTO_MAX_KEY_SIZE);
         WriteBlockBytes(cryptoBlankKeyData, keyAddresses[0], CRYPTO_MAX_KEY_SIZE);

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireApplicationDirectory.h
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireApplicationDirectory.h
@@ -58,7 +58,7 @@ This notice must be retained at the top of all source files where indicated.
 #endif
 
 #ifdef MEMORY_LIMITED_TESTING
-#define DESFIRE_MAX_KEYS                       (2)
+#define DESFIRE_MAX_KEYS                       (3)
 #else
 #ifdef DESFIRE_CUSTOM_MAX_KEYS
 #define DESFIRE_MAX_KEYS                       (DESFIRE_CUSTOM_MAX_KEYS)

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireCrypto.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireCrypto.c
@@ -37,6 +37,7 @@ This notice must be retained at the top of all source files where indicated.
 #include "DESFireISO14443Support.h"
 #include "DESFireStatusCodes.h"
 #include "DESFireLogging.h"
+#include "System.h"
 
 CryptoKeyBufferType SessionKey = { 0 };
 CryptoIVBufferType SessionIV = { 0 };
@@ -56,9 +57,11 @@ void InvalidateAuthState(BYTE keepPICCAuthData) {
     if (!keepPICCAuthData) {
         AuthenticatedWithPICCMasterKey = false;
         memset(&SessionKey[0], 0x00, CRYPTO_MAX_BLOCK_SIZE);
-        memset(&SessionIV[0], 0x00, CRYPTO_MAX_BLOCK_SIZE);
-        SessionIVByteSize = 0;
     }
+
+    memset(&SessionIV[0], 0x00, CRYPTO_MAX_BLOCK_SIZE);
+    SessionIVByteSize = 0;
+
     Authenticated = false;
     AuthenticatedWithKey = DESFIRE_NOT_AUTHENTICATED;
     Iso7816FileSelected = false;

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireFile.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireFile.c
@@ -308,6 +308,8 @@ uint16_t ReadDataFileIterator(uint8_t *Buffer) {
 
 uint8_t WriteDataFileInternal(uint8_t *Buffer, uint16_t ByteCount) {
     uint8_t Status;
+
+    //decipher?
     Status = WriteDataFileTransfer(Buffer, ByteCount);
     switch (Status) {
         case STATUS_OPERATION_OK:

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireFile.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireFile.c
@@ -337,7 +337,7 @@ uint8_t CreateFileCommonValidation(uint8_t FileNum) {
         return STATUS_AUTHENTICATION_ERROR;
     }
     uint8_t selectedKeyPerms = ReadKeySettings(SelectedApp.Slot, AuthenticatedWithKey);
-    if ((selectedKeyPerms & DESFIRE_FREE_CREATE_DELETE) == 0x00) {
+    if ((selectedKeyPerms & DESFIRE_FREE_CREATE_DELETE) == 0x00 && !AuthenticatedWithPICCMasterKey) {
         return STATUS_PERMISSION_DENIED;
     }
     return STATUS_OPERATION_OK;
@@ -350,6 +350,12 @@ uint8_t ValidateAuthentication(uint16_t AccessRights, uint16_t CheckMask) {
         GetReadWritePermissions(CheckMask & AccessRights),
         GetChangePermissions(CheckMask & AccessRights)
     };
+
+    if (DesfireDebuggingOn) {
+        const char *debugMsg = PSTR("Perm-R(%02x),W(%02x),RW(%02x),CHG(%02x)");
+        DEBUG_PRINT_P(debugMsg, SplitPerms[0], SplitPerms[1], SplitPerms[2], SplitPerms[3]);
+    }
+
     bool PermsRelevant[] = {
         CheckMask & VALIDATE_ACCESS_READ,
         CheckMask & VALIDATE_ACCESS_WRITE,

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireISO14443Support.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireISO14443Support.c
@@ -354,6 +354,9 @@ uint16_t ISO144433APiccProcess(uint8_t *Buffer, uint16_t BitCount) {
         StateRetryCount = 0;
     } else if (ISO14443ACmdIsWUPA(Cmd)) {
         DesfireLogEntry(LOG_INFO_APP_CMD_WUPA, NULL, 0);
+        //Resetting the selected app seems to be required but not docummented
+        const DESFireAidType Aid = {0,0,0};
+        SelectApp(Aid);
         ISO144433ASwitchState(ISO14443_3A_STATE_IDLE);
         StateRetryCount = 0;
     } else if (ISO144433AIsHalt(Buffer, BitCount)) {

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
@@ -801,7 +801,6 @@ uint16_t EV0CmdGetApplicationIds1(uint8_t *Buffer, uint16_t ByteCount) {
         return DESFIRE_STATUS_RESPONSE_SIZE;
     }
 
-    //(ReadKeySettings(SelectedApp.Slot, AuthenticatedWithKey) & DESFIRE_FREE_DIRECTORY_LIST)
     /* Verify authentication settings */
     if (!AMKFreeDirectoryListing()  && (AuthenticatedWithKey != DESFIRE_MASTER_KEY_ID)) {
         /* PICC master key authentication is required */
@@ -1229,7 +1228,7 @@ uint16_t EV0CmdReadData(uint8_t *Buffer, uint16_t ByteCount) {
     FileNum = Buffer[1];
     uint8_t fileIndex = LookupFileNumberIndex(SelectedApp.Slot, FileNum);
     if (fileIndex >= DESFIRE_MAX_FILES) {
-        Status = STATUS_PARAMETER_ERROR;
+        Status = STATUS_FILE_NOT_FOUND;
         DEBUG_PRINT_P(PSTR("FileIndexError"));
         return ExitWithStatus(Buffer, Status, DESFIRE_STATUS_RESPONSE_SIZE);
     }

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
@@ -311,6 +311,18 @@ static const DESFireCommand DESFireCommandSet[] = {
     },
 };
 
+//Sets the key number to a real key number after deriving the crypto type from it
+uint8_t ProcessKeyNumber(uint8_t * KeyNumber) {
+    if (*KeyNumber & APPLICATION_CRYPTO_AES) {
+        *KeyNumber = (*KeyNumber) & APPLICATION_CRYPTO_AES;
+        return CRYPTO_TYPE_AES128;
+    } else if (*KeyNumber & APPLICATION_CRYPTO_3K3DES) {
+        *KeyNumber = (*KeyNumber) & APPLICATION_CRYPTO_3K3DES;
+        return CRYPTO_TYPE_3K3DES;
+    }
+    return 0xFF;
+}
+
 uint16_t CallInstructionHandler(uint8_t *Buffer, uint16_t ByteCount) {
     if (ByteCount == 0) {
         Buffer[0] = STATUS_PARAMETER_ERROR;
@@ -1901,6 +1913,8 @@ uint16_t DesfireCmdAuthenticateAES1(uint8_t *Buffer, uint16_t ByteCount) {
 
     /* Check if we are authenticating with the PICC/Master key setup correctly */
     KeyId = Buffer[1];
+    uint8_t cryptoType = ProcessKeyNumber(&KeyId);
+
     if (SelectedApp.Slot == DESFIRE_PICC_APP_SLOT && KeyId != DESFIRE_MASTER_KEY_ID) {
         Buffer[0] = STATUS_PERMISSION_DENIED;
         return DESFIRE_STATUS_RESPONSE_SIZE;

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
@@ -796,13 +796,14 @@ uint16_t EV0CmdGetApplicationIds1(uint8_t *Buffer, uint16_t ByteCount) {
         return DESFIRE_STATUS_RESPONSE_SIZE;
     }
     /* Require the PICC app to be selected */
-    if (!AuthenticatedWithPICCMasterKey) {
+    if (SelectedApp.Slot != DESFIRE_PICC_APP_SLOT) {
         Buffer[0] = STATUS_PERMISSION_DENIED;
         return DESFIRE_STATUS_RESPONSE_SIZE;
     }
+
+    //(ReadKeySettings(SelectedApp.Slot, AuthenticatedWithKey) & DESFIRE_FREE_DIRECTORY_LIST)
     /* Verify authentication settings */
-    if ((ReadKeySettings(SelectedApp.Slot, AuthenticatedWithKey) & DESFIRE_FREE_DIRECTORY_LIST) &&
-            (AuthenticatedWithKey != DESFIRE_MASTER_KEY_ID)) {
+    if (!AMKFreeDirectoryListing()  && (AuthenticatedWithKey != DESFIRE_MASTER_KEY_ID)) {
         /* PICC master key authentication is required */
         Buffer[0] = STATUS_AUTHENTICATION_ERROR;
         return DESFIRE_STATUS_RESPONSE_SIZE;

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
@@ -344,7 +344,7 @@ uint16_t CallInstructionHandler(uint8_t *Buffer, uint16_t ByteCount) {
     uint16_t curInsIndex;
     DESFireCommand dfCmd;
     while (curInsUpper >= curInsLower) {
-        curInsIndex = curInsLower + (curInsUpper + 1 - curInsLower) / 2;
+        curInsIndex = (curInsLower + curInsUpper) / 2;
         dfCmd = DESFireCommandSet[curInsIndex];
         if (dfCmd.insCode == insCode) {
             if (dfCmd.insFunc == NULL) {

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireInstructions.c
@@ -621,8 +621,23 @@ uint16_t EV0CmdChangeKey(uint8_t *Buffer, uint16_t ByteCount) {
         Buffer[0] = STATUS_LENGTH_ERROR;
         return DESFIRE_STATUS_RESPONSE_SIZE;
     }
+
+        KeyId = Buffer[1];
+
+    /* Are we changing the card master key?
+     * Which crypto type are we using?
+     * TODO: Is this really ok for non master keys that are AES/3k3DES? */
+    uint8_t keySize = ByteCount - 2;
+    uint8_t cryptoType = 0xFF;
+
+    if (keySize == CRYPTO_AES_KEY_SIZE || keySize == CRYPTO_2KTDEA_KEY_SIZE || keySize == CRYPTO_3KTDEA_KEY_SIZE) {
+        cryptoType = ProcessKeyNumber(&KeyId);
+    } else {
+        Buffer[0] = STATUS_NO_SUCH_KEY;
+        return DESFIRE_STATUS_RESPONSE_SIZE;
+    }
+
     /* Validate number of keys, and make sure the KeyId is valid given the AID selected */
-    KeyId = Buffer[1];
     if (!KeyIdValid(SelectedApp.Slot, KeyId)) {
         Buffer[0] = STATUS_PARAMETER_ERROR;
         return DESFIRE_STATUS_RESPONSE_SIZE;

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireMemoryOperations.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireMemoryOperations.c
@@ -64,9 +64,11 @@ uint16_t AllocateBlocksMain(uint16_t BlockCount) {
     if (Block + BlockCount < Block || Block + BlockCount >= StorageSizeToBytes(Picc.StorageSize) || Block + BlockCount >= MEMORY_SIZE_PER_SETTING / BLOCKWISE_IO_MULTIPLIER) {
         return 0;
     }
+
     Picc.FirstFreeBlock = Block + BlockCount;
     DESFIRE_FIRST_FREE_BLOCK_ID = Picc.FirstFreeBlock;
     SynchronizePICCInfo();
+
     return Block;
 }
 

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFirePICCControl.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFirePICCControl.c
@@ -338,6 +338,7 @@ void FactoryFormatPiccEV1(uint8_t StorageSize) {
     Picc.SwVersionMajor = DESFIRE_SW_MAJOR_EV1;
     Picc.SwVersionMinor = DESFIRE_SW_MINOR_EV1;
     /* Reset the free block pointer */
+    InitBlockSizes();
     Picc.FirstFreeBlock = DESFIRE_FIRST_FREE_BLOCK_ID;
     /* Continue with user data initialization */
     SynchronizePICCInfo();

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFirePICCControl.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFirePICCControl.c
@@ -115,15 +115,15 @@ uint8_t ReadDataFilterSetup(uint8_t CommSettings) {
         case DESFIRE_COMMS_PLAINTEXT:
             break;
         case DESFIRE_COMMS_PLAINTEXT_MAC:
-            memset(SessionIV, PICC_EMPTY_BYTE, sizeof(SessionIV));
+            //memset(SessionIV, PICC_EMPTY_BYTE, sizeof(SessionIV));
             SessionIVByteSize = CRYPTO_2KTDEA_KEY_SIZE;
             break;
         case DESFIRE_COMMS_CIPHERTEXT_DES:
-            memset(SessionIV, PICC_EMPTY_BYTE, sizeof(SessionIV));
+            //memset(SessionIV, PICC_EMPTY_BYTE, sizeof(SessionIV));
             SessionIVByteSize = CRYPTO_3KTDEA_KEY_SIZE;
             break;
         case DESFIRE_COMMS_CIPHERTEXT_AES128:
-            memset(SessionIV, 0, sizeof(SessionIVByteSize));
+            //memset(SessionIV, 0, sizeof(SessionIVByteSize));
             SessionIVByteSize = CRYPTO_AES_KEY_SIZE;
         default:
             return STATUS_PARAMETER_ERROR;
@@ -134,19 +134,19 @@ uint8_t ReadDataFilterSetup(uint8_t CommSettings) {
 uint8_t WriteDataFilterSetup(uint8_t CommSettings) {
     switch (CommSettings) {
         case DESFIRE_COMMS_PLAINTEXT:
-            memset(SessionIV, 0, sizeof(SessionIVByteSize));
+            //memset(SessionIV, 0, sizeof(SessionIVByteSize));
             SessionIVByteSize = 0;
             break;
         case DESFIRE_COMMS_PLAINTEXT_MAC:
-            memset(SessionIV, 0, sizeof(SessionIVByteSize));
+            //memset(SessionIV, 0, sizeof(SessionIVByteSize));
             SessionIVByteSize = CRYPTO_2KTDEA_KEY_SIZE;
             break;
         case DESFIRE_COMMS_CIPHERTEXT_DES:
-            memset(SessionIV, 0, sizeof(SessionIVByteSize));
+            //memset(SessionIV, 0, sizeof(SessionIVByteSize));
             SessionIVByteSize = CRYPTO_AES_KEY_SIZE;
             break;
         case DESFIRE_COMMS_CIPHERTEXT_AES128:
-            memset(SessionIV, 0, sizeof(SessionIVByteSize));
+            //memset(SessionIV, 0, sizeof(SessionIVByteSize));
             SessionIVByteSize = CRYPTO_AES_KEY_SIZE;
             break;
         default:

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireUtils.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireUtils.c
@@ -148,6 +148,9 @@ bool DesfireCheckParityBits(uint8_t *Buffer, uint16_t BitCount) {
 
 uint16_t DesfirePreprocessAPDUWrapper(uint8_t CommMode, uint8_t *Buffer, uint16_t BufferSize, bool TruncateChecksumBytes) {
     uint16_t ChecksumBytes = 0;
+    const char *debugMsg = PSTR("Commode(%02x)");
+    DEBUG_PRINT_P(debugMsg, CommMode);
+
     switch (CommMode) {
         case DESFIRE_COMMS_PLAINTEXT_MAC: {
             if (DesfireCommandState.CryptoMethodType == CRYPTO_TYPE_DES || DesfireCommandState.CryptoMethodType == CRYPTO_TYPE_2KTDEA) {

--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFireUtils.h
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFireUtils.h
@@ -35,7 +35,7 @@ This notice must be retained at the top of all source files where indicated.
 #define ASBITS(bc)   ((bc) * BITS_PER_BYTE)
 
 #define GET_LE16(p)     (*((uint16_t*)&(p)[0]))
-#define GET_LE24(p)     (*((__uint24*)&(p)[0]))
+#define GET_LE24(p)     (*((__uint24*)&(p)[0])) // Careful! Don't use this if the first byte is LSB!!
 #define GET_LE32(p)     (*((uint32_t*)&(p)[0]))
 
 #define UnsignedTypeToUINT(typeValue) \

--- a/Firmware/Chameleon-Mini/Application/MifareDESFire.c
+++ b/Firmware/Chameleon-Mini/Application/MifareDESFire.c
@@ -121,8 +121,8 @@ void MifareDesfireAppReset(void) {
 
 void MifareDesfireAppTick(void) {
     if (!CheckStateRetryCount(false)) {
-        ResetISOState();
-        MifareDesfireReset();
+        //ResetISOState();
+        //MifareDesfireReset();
     }
 }
 

--- a/Firmware/Chameleon-Mini/Application/MifareDESFire.c
+++ b/Firmware/Chameleon-Mini/Application/MifareDESFire.c
@@ -428,7 +428,7 @@ uint16_t MifareDesfireAppProcess(uint8_t *Buffer, uint16_t BitCount) {
         }
         ProcessedByteCount = DesfirePostprocessAPDU(ActiveCommMode, Buffer, ProcessedByteCount);
         return ISO14443AStoreLastDataFrameAndReturn(Buffer, ASBITS(ProcessedByteCount));
-    } else if ((ByteCount >= 8 && DesfireCLA(Buffer[1]) &&
+    } else if ((ByteCount >= 8 && Buffer[1] == DESFIRE_NATIVE_CLA &&
                 Buffer[3] == 0x00 && Buffer[4] == 0x00 && Buffer[5] == ByteCount - 8) ||
                (ByteCount >= 9 && DesfireCLA(Buffer[1]) &&
                 Buffer[3] == 0x00 && Buffer[4] == 0x00 && Buffer[5] == ByteCount - 9)) {

--- a/Firmware/Chameleon-Mini/BuildScripts/custom_build_targets.mk
+++ b/Firmware/Chameleon-Mini/BuildScripts/custom_build_targets.mk
@@ -71,7 +71,7 @@ desfire-gallagher: EXTRA_CONFIG_SETTINGS:=-DDESFIRE_CUSTOM_MAX_APPS=3
 				-DDESFIRE_CUSTOM_MAX_KEYS=3 \
 				-DDESFIRE_CRYPTO1_SAVE_SPACE \
 				-finline-small-functions
-desfire-gallagher: TARGET_CUSTOM_BUILD_NAME:=DESFire
+desfire-gallagher: TARGET_CUSTOM_BUILD_NAME:=DESFire_Gallagher
 desfire-gallagher: CONFIG_SETTINGS:=$(SUPPORTED_TAGS_BUILD) -DDEFAULT_CONFIGURATION=CONFIG_NONE $(EXTRA_CONFIG_SETTINGS)
 desfire-gallagher: custom-build
 

--- a/Firmware/Chameleon-Mini/BuildScripts/custom_build_targets.mk
+++ b/Firmware/Chameleon-Mini/BuildScripts/custom_build_targets.mk
@@ -61,20 +61,6 @@ desfire: TARGET_CUSTOM_BUILD_NAME:=DESFire
 desfire: CONFIG_SETTINGS:=$(SUPPORTED_TAGS_BUILD) -DDEFAULT_CONFIGURATION=CONFIG_NONE $(EXTRA_CONFIG_SETTINGS)
 desfire: custom-build
 
-desfire-gallagher: FLASH_DATA_SIZE_CONST:=0F000 # Eight settings (save some space): 4 * 0x2000
-desfire-gallagher: FLASH_DATA_SIZE:=0x$(FLASH_DATA_SIZE_CONST)
-desfire-gallagher: FLASH_DATA_SIZE_UPPER_CONST:=20000
-desfire-gallagher: FLASH_DATA_ADDR:=0x$(shell echo $$(( 0x$(FLASH_DATA_SIZE_UPPER_CONST) - 0x$(FLASH_DATA_SIZE_CONST) )) | xargs -0 printf %X)
-desfire-gallagher: SUPPORTED_TAGS_BUILD:=-DCONFIG_MF_DESFIRE_SUPPORT
-desfire-gallagher: EXTRA_CONFIG_SETTINGS:=-DDESFIRE_CUSTOM_MAX_APPS=3
-                -DDESFIRE_CUSTOM_MAX_FILES=4  \
-				-DDESFIRE_CUSTOM_MAX_KEYS=3 \
-				-DDESFIRE_CRYPTO1_SAVE_SPACE \
-				-finline-small-functions
-desfire-gallagher: TARGET_CUSTOM_BUILD_NAME:=DESFire_Gallagher
-desfire-gallagher: CONFIG_SETTINGS:=$(SUPPORTED_TAGS_BUILD) -DDEFAULT_CONFIGURATION=CONFIG_NONE $(EXTRA_CONFIG_SETTINGS)
-desfire-gallagher: custom-build
-
 desfire-dev: FLASH_DATA_SIZE_CONST:=08000 # Four settings (save some space): 4 * 0x2000
 desfire-dev: FLASH_DATA_SIZE:=0x$(FLASH_DATA_SIZE_CONST)
 desfire-dev: FLASH_DATA_SIZE_UPPER_CONST:=20000

--- a/Firmware/Chameleon-Mini/BuildScripts/custom_build_targets.mk
+++ b/Firmware/Chameleon-Mini/BuildScripts/custom_build_targets.mk
@@ -61,6 +61,20 @@ desfire: TARGET_CUSTOM_BUILD_NAME:=DESFire
 desfire: CONFIG_SETTINGS:=$(SUPPORTED_TAGS_BUILD) -DDEFAULT_CONFIGURATION=CONFIG_NONE $(EXTRA_CONFIG_SETTINGS)
 desfire: custom-build
 
+desfire-gallagher: FLASH_DATA_SIZE_CONST:=0F000 # Eight settings (save some space): 4 * 0x2000
+desfire-gallagher: FLASH_DATA_SIZE:=0x$(FLASH_DATA_SIZE_CONST)
+desfire-gallagher: FLASH_DATA_SIZE_UPPER_CONST:=20000
+desfire-gallagher: FLASH_DATA_ADDR:=0x$(shell echo $$(( 0x$(FLASH_DATA_SIZE_UPPER_CONST) - 0x$(FLASH_DATA_SIZE_CONST) )) | xargs -0 printf %X)
+desfire-gallagher: SUPPORTED_TAGS_BUILD:=-DCONFIG_MF_DESFIRE_SUPPORT
+desfire-gallagher: EXTRA_CONFIG_SETTINGS:=-DDESFIRE_CUSTOM_MAX_APPS=3
+                -DDESFIRE_CUSTOM_MAX_FILES=4  \
+				-DDESFIRE_CUSTOM_MAX_KEYS=3 \
+				-DDESFIRE_CRYPTO1_SAVE_SPACE \
+				-finline-small-functions
+desfire-gallagher: TARGET_CUSTOM_BUILD_NAME:=DESFire
+desfire-gallagher: CONFIG_SETTINGS:=$(SUPPORTED_TAGS_BUILD) -DDEFAULT_CONFIGURATION=CONFIG_NONE $(EXTRA_CONFIG_SETTINGS)
+desfire-gallagher: custom-build
+
 desfire-dev: FLASH_DATA_SIZE_CONST:=08000 # Four settings (save some space): 4 * 0x2000
 desfire-dev: FLASH_DATA_SIZE:=0x$(FLASH_DATA_SIZE_CONST)
 desfire-dev: FLASH_DATA_SIZE_UPPER_CONST:=20000


### PR DESCRIPTION
I've been working on getting the Chameleon to work with Gallagher authentication on DESFire. This PR includes code for the very basic ability for:
- Writing Gallagher data onto the Chameleon in DESFire EV1 4k mode using Proxmark
- Reading that data back using Proxmark

It also includes:
- Fix of the binary search for DESFire commands.
- Removal of resetting the card every tick.
- Reclaim of allocated blocks when formatting the PICC.
- Fixed CRC32 for DESFire.
- New CMAC functions (adapted from the Proxmark library) that pass my tests for DESFire use
- Ability to keep updating the IV during DESFire operations (this is not called in every function that requires it yet, but the support is there). This calculates CMAC of incoming commands.
- Ability to change the master key type to AES even if the reader identifies the AES master key as number 0x80.
- Reset the selected AID to 000000 after WUPA which seems to be needed but not documented.
- Very limited support for encrypted file reading and writing (maximum 32 bytes of encrypted data, including CRC, is supported). This is not for the fully encrypted communication but when the comm is done in plain and the file is set to be read/written encrypted.

This is my first contribution to the project. Testing is very much needed from someone else too (I tested as much as I could).

Gallagher read using Proxmark from Chameleon (note - includes extra debugging info from PM3)

> [usb] pm3 --> hf gallagher reader --apdu
>[+] Setting ISODEP -> inactive                                                                                             
>[+] Setting ISODEP -> inactive                                                                                            
>[+] >>>> 90 5A 00 00 03 F4 81 2F 00                                                                                        
> [+] Setting ISODEP -> inactive                                                                                             
> [+] Setting ISODEP -> NFC-A                                                                                                
> [+] <<<< 91 00                                                                                                             
> [+] >>>> 90 BD 00 00 07 00 00 00 00 24 00 00 00                                                                            
> [+] <<<< 02 03 F8 20 81 F4 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 91 00 
> [+] Setting ISODEP -> inactive                                                                                             
> [+] >>>> 90 5A 00 00 03 F4 81 20 00                                                                                        
> [+] Setting ISODEP -> inactive                                                                                             
> [+] Setting ISODEP -> NFC-A                                                                                                
> [+] <<<< 91 00                                                                                                             
> [=] IV: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  [0] (null)                                                        
> [=] IV: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  [0]                                                               
> [+] >>>> 90 AA 00 00 01 00 00                                                                                              
> [+] <<<< 38 1D E0 9A 30 ED 7B 7F 90 22 C7 1D F2 7E 95 A0 91 AF                                                             
> [=] IV: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  [0] (null)                                                        
> [=] IV: 38 1D E0 9A 30 ED 7B 7F 90 22 C7 1D F2 7E 95 A0  [0] (null)                                                       
> [+] >>>> 90 AF 00 00 20 48 EA C4 15 E3 62 24 45 E5 BE EA B6 80 41 76 B6 9A F4 93 42 98 53 6B EC 44 EF 27 A4 CC 7C 56 CC 00 [+] <<<< D9 69 5F B5 87 DF 2B E8 1A 2D FF 5B 96 57 61 2B 91 00                                                             
> [=] IV: 9A F4 93 42 98 53 6B EC 44 EF 27 A4 CC 7C 56 CC  [0] (null)                                                        
> [=] CMAC over: BD 00 00 00 00 10 00 00                                                                                     
> [=] IV: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  [0] (null)                                                        
> [=] IV: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  [0]                                                               
> [+] >>>> 90 BD 00 00 07 00 00 00 00 10 00 00 00                                                                            
> [+] <<<< 8C 9B 6F E5 A4 A8 01 EC BC 9C F8 35 A7 A9 9F BE AE 54 16 07 FA A8 42 2D 03 E4 08 EF 92 EC 1D 6D 91 00             [=] IV: DD C7 0A 5D 86 33 16 DF A0 11 78 5C A8 E4 77 57  [0]                                                                                                                                                                                                                                                                                                 
> [+] Gallagher (AID 2081F4) - region: C ( 2 ), facility: 1111, card number: 438456, issue level: 1 