### PR TITLE
DESFire: Fix loading from flash when changing slots

### DIFF
--- a/Firmware/Chameleon-Mini/Application/DESFire/DESFirePICCControl.c
+++ b/Firmware/Chameleon-Mini/Application/DESFire/DESFirePICCControl.c
@@ -175,6 +175,7 @@ void InitialisePiccBackendEV0(uint8_t StorageSize, bool formatPICC) {
         MemoryRestoreDesfireHeaderBytes(false);
         ReadBlockBytes(&AppDir, DESFIRE_APP_DIR_BLOCK_ID, sizeof(DESFireAppDirType));
         DesfireATQAReset = true;
+        SelectedApp.Slot = (uint8_t) -1;
         SelectPiccApp();
     }
 }
@@ -195,6 +196,7 @@ void InitialisePiccBackendEV1(uint8_t StorageSize, bool formatPICC) {
         MemoryRestoreDesfireHeaderBytes(false);
         ReadBlockBytes(&AppDir, DESFIRE_APP_DIR_BLOCK_ID, sizeof(DESFireAppDirType));
         DesfireATQAReset = true;
+        SelectedApp.Slot = (uint8_t) -1;
         SelectPiccApp();
     }
 }
@@ -215,6 +217,7 @@ void InitialisePiccBackendEV2(uint8_t StorageSize, bool formatPICC) {
         MemoryRestoreDesfireHeaderBytes(false);
         ReadBlockBytes(&AppDir, DESFIRE_APP_DIR_BLOCK_ID, sizeof(DESFireAppDirType));
         DesfireATQAReset = true;
+        SelectedApp.Slot = (uint8_t) -1;
         SelectPiccApp();
     }
 


### PR DESCRIPTION
After setting up a DESFire card in a slot (setting), it was not possible to switch to a different setting and then back. There was an error in the loading of the DESFire slot config (setting), which resulted in part of the data in the flash being overwritten by zeros.

This PR fixes that. It is now possible to switch to set up a DESFire card in a slot (setting), switch to a different one and then back. Everything seems to load correctly. This also fixes loading after reboot.

**Another way of saying the above is that this PR fixes loading a DESFire card from flash to FRAM.**

An example of what used to be broken but works now in terms of terminal commands:
`SETTING=1`
`CONFIG=MF_DESFIRE_4KEV1`
(...) load something onto the card (...)
`STORE`
`SETTING=2`
(...) do stuff (...)
`SETTING=1`
`RECALL`
now the DESFire card would not load correctly