### PR TITLE
Initialize configuration after Log initialization

### DIFF
--- a/Firmware/Chameleon-Mini/Chameleon-Mini.c
+++ b/Firmware/Chameleon-Mini/Chameleon-Mini.c
@@ -7,12 +7,12 @@ int main(void) {
     PinInit();
     MemoryInit();
     CodecInitCommon();
-    ConfigurationInit();
     TerminalInit();
     RandomInit();
     ButtonInit();
     AntennaLevelInit();
     LogInit();
+    ConfigurationInit();
     SystemInterruptInit();
 
     while (1) {


### PR DESCRIPTION
Right now if you call LogEntry() from an AppInit() function the system will hang with no warning. This simple change allows you to call this function in AppInit() without any problems.